### PR TITLE
Local instance service mode

### DIFF
--- a/cmd/aem/config.go
+++ b/cmd/aem/config.go
@@ -75,6 +75,7 @@ func (c *CLI) configValuesCmd() *cobra.Command {
 		Aliases: []string{"get-all"},
 		Short:   "Read all configuration values",
 		Run: func(cmd *cobra.Command, args []string) {
+			c.SetOutput("file", cfg.FileEffective())
 			c.SetOutput("values", c.config.Values())
 			c.Ok("config values read")
 		},

--- a/cmd/aem/config.go
+++ b/cmd/aem/config.go
@@ -76,7 +76,7 @@ func (c *CLI) configValuesCmd() *cobra.Command {
 		Short:   "Read all configuration values",
 		Run: func(cmd *cobra.Command, args []string) {
 			c.SetOutput("file", cfg.FileEffective())
-			c.SetOutput("values", c.config.Values())
+			c.SetOutput("values", c.config.ValuesMap())
 			c.Ok("config values read")
 		},
 	}
@@ -100,13 +100,13 @@ func (c *CLI) configValueCmd() *cobra.Command {
 				err   error
 			)
 			if key != "" {
-				value, err = tplx.RenderKey(key, c.config.Values())
+				value, err = tplx.RenderKey(key, c.config.ValuesMap())
 				if err != nil {
 					c.Error(fmt.Errorf("cannot read config value using key '%s': %w", key, err))
 					return
 				}
 			} else {
-				value, err = tplx.RenderString(template, c.config.Values())
+				value, err = tplx.RenderString(template, c.config.ValuesMap())
 				if err != nil {
 					c.Error(fmt.Errorf("cannot read config value using template '%s': %w", template, err))
 					return

--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -35,6 +35,10 @@ func (c *Config) Values() *ConfigValues {
 	return c.values
 }
 
+func (c *Config) ValuesMap() map[string]any {
+	return c.viper.AllSettings()
+}
+
 // NewConfig creates a new config
 func NewConfig() *Config {
 	result := new(Config)

--- a/pkg/cfg/defaults.go
+++ b/pkg/cfg/defaults.go
@@ -50,6 +50,8 @@ func setDefaults(v *viper.Viper) {
 		"java.util.ResourceBundle",
 	})
 
+	v.SetDefault("instance.local.service_mode", false)
+
 	v.SetDefault("instance.package.snapshot_deploy_skipping", true)
 
 	v.SetDefault("instance.repo.property_change_ignored", []string{

--- a/pkg/cfg/values.go
+++ b/pkg/cfg/values.go
@@ -99,6 +99,7 @@ type ConfigValues struct {
 			BackupDir   string `mapstructure:"backup_dir" yaml:"backup_dir"`
 			OverrideDir string `mapstructure:"override_dir" yaml:"override_dir"`
 			ToolDir     string `mapstructure:"tool_dir" yaml:"tool_dir"`
+			ServiceMode bool   `mapstructure:"service_mode" yaml:"service_mode"`
 
 			Quickstart struct {
 				DistFile    string `mapstructure:"dist_file" yaml:"dist_file"`

--- a/pkg/check.go
+++ b/pkg/check.go
@@ -314,7 +314,7 @@ func (c ReachableHTTPChecker) Check(instance Instance) CheckResult {
 	}
 	return CheckResult{
 		ok:      false,
-		message: fmt.Sprintf("not reachable: %s", address),
+		message: fmt.Sprintf("not reachable (%s)", address),
 	}
 }
 
@@ -344,14 +344,14 @@ func (c PathHTTPChecker) Check(instance Instance) CheckResult {
 	if err != nil {
 		return CheckResult{
 			ok:      false,
-			message: fmt.Sprintf("%s: request error", c.Name),
+			message: fmt.Sprintf("%s request error", c.Name),
 			err:     err,
 		}
 	}
 	if c.ResponseCode > 0 && response.StatusCode() != c.ResponseCode {
 		return CheckResult{
 			ok:      false,
-			message: fmt.Sprintf("%s: responds with unexpected code '%d'", c.Name, response.StatusCode()),
+			message: fmt.Sprintf("%s responds with unexpected code (%d)", c.Name, response.StatusCode()),
 		}
 	}
 	if c.ResponseText != "" {
@@ -367,7 +367,7 @@ func (c PathHTTPChecker) Check(instance Instance) CheckResult {
 		if !strings.Contains(text, c.ResponseText) {
 			return CheckResult{
 				ok:      false,
-				message: fmt.Sprintf("%s responds without text '%s'", c.Name, c.ResponseText),
+				message: fmt.Sprintf("%s responds without text: %s", c.Name, c.ResponseText),
 			}
 		}
 	}

--- a/pkg/check.go
+++ b/pkg/check.go
@@ -316,6 +316,33 @@ func (c ReachableHTTPChecker) Check(instance Instance) CheckResult {
 	}
 }
 
+func NewPathHTTPChecker(path string, statusCode int, containedText string) PathHTTPChecker {
+	return PathHTTPChecker{
+		Path:          path,
+		StatusCode:    statusCode,
+		ContainedText: containedText,
+	}
+}
+
+func (c PathHTTPChecker) Spec() CheckSpec {
+	return CheckSpec{Mandatory: false}
+}
+
+type PathHTTPChecker struct {
+	Path          string
+	StatusCode    int
+	ContainedText string
+}
+
+func (c PathHTTPChecker) Check(_ Instance) CheckResult {
+	// TODO implement this
+
+	return CheckResult{
+		ok:      false, // TODO true
+		message: fmt.Sprintf("path checked: %s", c.Path),
+	}
+}
+
 func bundleStablePercent(bundles *osgi.BundleList, unstableBundles []osgi.BundleListItem) string {
 	return stringsx.PercentExplained(bundles.Total()-len(unstableBundles), bundles.Total(), 0)
 }

--- a/pkg/common/fmtx/serialization.go
+++ b/pkg/common/fmtx/serialization.go
@@ -110,9 +110,15 @@ type TextMarshaler interface {
 }
 
 func MarshalText(value any) string {
+	var result string
 	marshaller, ok := value.(TextMarshaler)
 	if ok {
-		return marshaller.MarshalText()
+		result = marshaller.MarshalText()
+	} else {
+		result = fmt.Sprintf("%v", value)
 	}
-	return fmt.Sprintf("%v", value)
+	if len(result) == 0 {
+		return "<empty>"
+	}
+	return result
 }

--- a/pkg/http.go
+++ b/pkg/http.go
@@ -17,12 +17,12 @@ type HTTP struct {
 
 func NewHTTP(instance *Instance, baseURL string) *HTTP {
 	return &HTTP{
-		client:   newInstanceHTTPClient(baseURL),
+		client:   NewResty(baseURL),
 		instance: instance,
 	}
 }
 
-func newInstanceHTTPClient(baseURL string) *resty.Client {
+func NewResty(baseURL string) *resty.Client {
 	client := resty.New()
 	client.SetBaseURL(baseURL)
 	client.SetDisableWarn(true)
@@ -35,7 +35,7 @@ func (hc *HTTP) Request() *resty.Request {
 }
 
 func (hc *HTTP) RequestWithOptions(options func(client *resty.Client)) *resty.Request {
-	client := newInstanceHTTPClient(hc.BaseURL()).SetBasicAuth(hc.instance.User(), hc.instance.Password())
+	client := NewResty(hc.BaseURL()).SetBasicAuth(hc.instance.User(), hc.instance.Password())
 	options(client)
 	return client.R()
 }

--- a/pkg/instance_manager_check.go
+++ b/pkg/instance_manager_check.go
@@ -39,7 +39,7 @@ func (im *InstanceManager) NewCheckOpts() *CheckOpts {
 		StatusStopped:       NewStatusStoppedChecker(),
 		AwaitStoppedTimeout: NewTimeoutChecker("stopped", time.Minute*10),
 		Unreachable:         NewReachableChecker(false),
-		LoginPage:           NewPathHTTPChecker("/libs/granite/core/content/login.html", 200, "QUICKSTART_HOMEPAGE"),
+		LoginPage:           NewPathHTTPChecker("login page", "/libs/granite/core/content/login.html", 200, "QUICKSTART_HOMEPAGE"),
 	}
 }
 

--- a/pkg/local_instance.go
+++ b/pkg/local_instance.go
@@ -81,6 +81,15 @@ func NewLocal(i *Instance) *LocalInstance {
 }
 
 func (li LocalInstance) State() LocalInstanceState {
+	if li.Opts().ServiceMode {
+		return LocalInstanceState{
+			ID:         li.instance.ID(),
+			URL:        li.instance.http.BaseURL(),
+			Attributes: li.instance.Attributes(),
+			AemVersion: li.instance.AemVersion(),
+			Dir:        li.Dir(),
+		}
+	}
 	return LocalInstanceState{
 		ID:           li.instance.ID(),
 		URL:          li.instance.http.BaseURL(),

--- a/pkg/local_instance_manager.go
+++ b/pkg/local_instance_manager.go
@@ -432,4 +432,6 @@ func (im *InstanceManager) configureLocalOpts(config *cfg.Config) {
 	if len(opts.OakRun.StorePath) > 0 {
 		im.LocalOpts.OakRun.StorePath = opts.OakRun.StorePath
 	}
+
+	im.LocalOpts.ServiceMode = opts.ServiceMode
 }

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -70,18 +70,6 @@ var appClassicFiles embed.FS
 var appCloudFiles embed.FS
 
 func (p Project) InitializeWithChanged(kind Kind) (bool, error) {
-	projectChanged, err := p.initializeWithChanged(kind)
-	if err != nil {
-		return false, err
-	}
-	configChanged, err := p.config.InitializeWithChanged()
-	if err != nil {
-		return false, err
-	}
-	return projectChanged || configChanged, nil
-}
-
-func (p Project) initializeWithChanged(kind Kind) (bool, error) {
 	if p.config.TemplateFileExists() {
 		return false, nil
 	}


### PR DESCRIPTION
fixes #99 
fixes #95 

- aem/home/etc/aem.yml is not needed; but when it exists it has precedence over aem/defaults/etc/aem.yml
- `sh aemw config init` copies default config to home config (explicit action to do)
- config value/values improvements
- login page health check needed for #99 
- `AEM_INSTANCE_LOCAL_SERVICE_MODE=true` useful for systemd integration when no instance password is stored on machine

