### PR TITLE
Output log mode (both to console and file)

### DIFF
--- a/cmd/aem/cli.go
+++ b/cmd/aem/cli.go
@@ -125,7 +125,7 @@ func (c *CLI) configureOutput() {
 	if c.outputFormat == fmtx.Text {
 		switch c.outputLogMode {
 		case cfg.OutputLogConsole:
-			outputWriter = c.aem.Output() // use default / STDOUT
+			outputWriter = os.Stdout
 			break
 		case cfg.OutputLogFile:
 			outputWriter = c.openOutputLogFile()

--- a/cmd/aem/root.go
+++ b/cmd/aem/root.go
@@ -51,9 +51,9 @@ func (c *CLI) rootFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVar(&(c.config.Values().Output.Log.File),
 		"output-log-file", c.config.Values().Output.Log.File,
 		"Controls output file path")
-	cmd.PersistentFlags().BoolVar(&(c.config.Values().Output.Log.Console),
-		"output-log-console", c.config.Values().Output.Log.Console,
-		"Print outputs and log entries to console instead of writing to file (when format is \"text\")")
+	cmd.PersistentFlags().StringVar(&(c.config.Values().Output.Log.Mode),
+		"output-log-mode", c.config.Values().Output.Log.Mode,
+		"Controls where outputs and logs should be written to when format is \"text\""+(strings.Join(cfg.OutputLogModes(), "|")+")"))
 	cmd.PersistentFlags().StringVar(&(c.config.Values().Output.Value),
 		"output-value", c.config.Values().Output.Value,
 		"Limits output to single variable")

--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -192,6 +192,16 @@ func OutputFormats() []string {
 	return []string{fmtx.Text, fmtx.YML, fmtx.JSON}
 }
 
+const (
+	OutputLogFile    = "file"
+	OutputLogConsole = "console"
+	OutputLogBoth    = "both"
+)
+
+func OutputLogModes() []string {
+	return []string{OutputLogConsole, OutputLogFile, OutputLogBoth}
+}
+
 func (c *Config) ConfigureLogger() {
 	log.SetFormatter(&log.TextFormatter{
 		TimestampFormat: c.values.Log.TimestampFormat,

--- a/pkg/cfg/config.go
+++ b/pkg/cfg/config.go
@@ -193,26 +193,14 @@ func OutputFormats() []string {
 }
 
 const (
+	OutputLogNone    = "none"
 	OutputLogFile    = "file"
 	OutputLogConsole = "console"
 	OutputLogBoth    = "both"
 )
 
 func OutputLogModes() []string {
-	return []string{OutputLogConsole, OutputLogFile, OutputLogBoth}
-}
-
-func (c *Config) ConfigureLogger() {
-	log.SetFormatter(&log.TextFormatter{
-		TimestampFormat: c.values.Log.TimestampFormat,
-		FullTimestamp:   c.values.Log.FullTimestamp,
-		ForceColors:     !c.values.Output.NoColor,
-	})
-	level, err := log.ParseLevel(c.values.Log.Level)
-	if err != nil {
-		log.Fatalf("unsupported log level specified: '%s'", c.values.Log.Level)
-	}
-	log.SetLevel(level)
+	return []string{OutputLogConsole, OutputLogFile, OutputLogBoth, OutputLogNone}
 }
 
 func (c *Config) ExportWithChanged(file string) (bool, error) {

--- a/pkg/cfg/values.go
+++ b/pkg/cfg/values.go
@@ -25,8 +25,8 @@ type ConfigValues struct {
 		NoColor bool   `mapstructure:"no_color" yaml:"no_color"`
 		Value   string `mapstructure:"value" yaml:"value"`
 		Log     struct {
-			File    string `mapstructure:"file" yaml:"file"`
-			Console bool   `mapstructure:"console" yaml:"console"`
+			File string `mapstructure:"file" yaml:"file"`
+			Mode string `mapstructure:"mode" yaml:"mode"`
 		} `mapstructure:"log" yaml:"log"`
 	} `mapstructure:"output" yaml:"output"`
 

--- a/pkg/facade.go
+++ b/pkg/facade.go
@@ -28,8 +28,17 @@ func NewAem() *Aem {
 	return result
 }
 
+func (a *Aem) Output() io.Writer {
+	return a.output
+}
+
 func (a *Aem) SetOutput(output io.Writer) {
 	a.output = output
+}
+
+func (a *Aem) CommandOutput(cmd *exec.Cmd) {
+	cmd.Stdout = a.output
+	cmd.Stderr = a.output
 }
 
 func (a *Aem) BaseOpts() *base.Opts {
@@ -48,9 +57,4 @@ func (a *Aem) Configure(config *cfg.Config) {
 	a.baseOpts.Configure(config)
 	a.javaOpts.Configure(config)
 	a.instanceManager.Configure(config)
-}
-
-func (a *Aem) CommandOutput(cmd *exec.Cmd) {
-	cmd.Stdout = a.output
-	cmd.Stderr = a.output
 }

--- a/pkg/project/app_classic/aem/default/etc/aem.yml
+++ b/pkg/project/app_classic/aem/default/etc/aem.yml
@@ -192,5 +192,5 @@ output:
   log:
     # File path of logs written especially when output format is different than 'text'
     file: aem/home/var/log/aem.log
-    # Controls if script outputs and log entries should be printed to console instead of written to file when output format is 'text'
-    console: true
+    # Controls where outputs and logs should be written to when format is 'text' (console|file|both)
+    mode: console

--- a/pkg/project/app_cloud/aem/default/etc/aem.yml
+++ b/pkg/project/app_cloud/aem/default/etc/aem.yml
@@ -192,5 +192,5 @@ output:
   log:
     # File path of logs written especially when output format is different than 'text'
     file: aem/home/var/log/aem.log
-    # Controls if script outputs and log entries should be printed to console instead of written to file when output format is 'text'
-    console: true
+    # Controls where outputs and logs should be written to when format is 'text' (console|file|both)
+    mode: console


### PR DESCRIPTION
when AEM is started/stopped by systemd the only way to preview logs/current status is tailing /var/log/messages
when some action is executed afterwards like repl agent setup / crx/de then there is a need to preview also aem.log;

intention of this change is to have single place to preview aem operation logs - aem.log