### PR TITLE
Package workflow launcher toggle + repo cp/mv cmd

### DIFF
--- a/cmd/aem/osgi.go
+++ b/cmd/aem/osgi.go
@@ -595,9 +595,6 @@ func (c *CLI) osgiConfigSave() *cobra.Command {
 				if err != nil {
 					return nil, err
 				}
-				if changed {
-					c.aem.InstanceManager().AwaitStartedOne(instance)
-				}
 				return map[string]any{
 					OutputChanged: changed,
 					"config":      config,
@@ -605,6 +602,10 @@ func (c *CLI) osgiConfigSave() *cobra.Command {
 				}, nil
 			})
 			if err != nil {
+				c.Error(err)
+				return
+			}
+			if err := c.aem.InstanceManager().AwaitStarted(InstancesChanged(saved)); err != nil {
 				c.Error(err)
 				return
 			}
@@ -637,9 +638,6 @@ func (c *CLI) osgiConfigDelete() *cobra.Command {
 				if err != nil {
 					return nil, err
 				}
-				if changed {
-					c.aem.InstanceManager().AwaitStartedOne(instance)
-				}
 				return map[string]any{
 					OutputChanged: changed,
 					"config":      config,
@@ -647,6 +645,10 @@ func (c *CLI) osgiConfigDelete() *cobra.Command {
 				}, nil
 			})
 			if err != nil {
+				c.Error(err)
+				return
+			}
+			if err := c.aem.InstanceManager().AwaitStarted(InstancesChanged(deleted)); err != nil {
 				c.Error(err)
 				return
 			}

--- a/cmd/aem/package.go
+++ b/cmd/aem/package.go
@@ -186,8 +186,15 @@ func (c *CLI) pkgDeployCmd() *cobra.Command {
 				c.Error(err)
 				return
 			}
+			force, _ := cmd.Flags().GetBool("force")
 			deployed, err := pkg.InstanceProcess(c.aem, instances, func(instance pkg.Instance) (map[string]any, error) {
-				changed, err := instance.PackageManager().DeployWithChanged(path)
+				changed := false
+				if force {
+					err = instance.PackageManager().Deploy(path)
+					changed = true
+				} else {
+					changed, err = instance.PackageManager().DeployWithChanged(path)
+				}
 				if err != nil {
 					return nil, err
 				}
@@ -218,6 +225,7 @@ func (c *CLI) pkgDeployCmd() *cobra.Command {
 		},
 	}
 	pkgDefineFileAndUrlFlags(cmd)
+	cmd.Flags().BoolP("force", "f", false, "Deploy even when already deployed")
 	return cmd
 }
 

--- a/cmd/aem/package.go
+++ b/cmd/aem/package.go
@@ -96,9 +96,6 @@ func (c *CLI) pkgUploadCmd() *cobra.Command {
 				if err != nil {
 					return nil, err
 				}
-				if changed {
-					c.aem.InstanceManager().AwaitStartedOne(instance)
-				}
 				p, err := instance.PackageManager().ByFile(path)
 				if err != nil {
 					return nil, err
@@ -110,6 +107,10 @@ func (c *CLI) pkgUploadCmd() *cobra.Command {
 				}, nil
 			})
 			if err != nil {
+				c.Error(err)
+				return
+			}
+			if err := c.aem.InstanceManager().AwaitStarted(InstancesChanged(uploaded)); err != nil {
 				c.Error(err)
 				return
 			}
@@ -144,9 +145,6 @@ func (c *CLI) pkgInstallCmd() *cobra.Command {
 				if err != nil {
 					return nil, err
 				}
-				if changed {
-					c.aem.InstanceManager().AwaitStartedOne(instance)
-				}
 				return map[string]any{
 					OutputChanged: changed,
 					"package":     p,
@@ -154,6 +152,10 @@ func (c *CLI) pkgInstallCmd() *cobra.Command {
 				}, nil
 			})
 			if err != nil {
+				c.Error(err)
+				return
+			}
+			if err := c.aem.InstanceManager().AwaitStarted(InstancesChanged(installed)); err != nil {
 				c.Error(err)
 				return
 			}
@@ -189,9 +191,6 @@ func (c *CLI) pkgDeployCmd() *cobra.Command {
 				if err != nil {
 					return nil, err
 				}
-				if changed {
-					c.aem.InstanceManager().AwaitStartedOne(instance)
-				}
 				p, err := instance.PackageManager().ByFile(path)
 				if err != nil {
 					return nil, err
@@ -203,6 +202,10 @@ func (c *CLI) pkgDeployCmd() *cobra.Command {
 				}, nil
 			})
 			if err != nil {
+				c.Error(err)
+				return
+			}
+			if err := c.aem.InstanceManager().AwaitStarted(InstancesChanged(deployed)); err != nil {
 				c.Error(err)
 				return
 			}
@@ -237,9 +240,6 @@ func (c *CLI) pkgUninstallCmd() *cobra.Command {
 				if err != nil {
 					return nil, err
 				}
-				if changed {
-					c.aem.InstanceManager().AwaitStartedOne(instance)
-				}
 				return map[string]any{
 					OutputChanged: changed,
 					"package":     p,
@@ -247,6 +247,10 @@ func (c *CLI) pkgUninstallCmd() *cobra.Command {
 				}, nil
 			})
 			if err != nil {
+				c.Error(err)
+				return
+			}
+			if err := c.aem.InstanceManager().AwaitStarted(InstancesChanged(uninstalled)); err != nil {
 				c.Error(err)
 				return
 			}
@@ -281,9 +285,6 @@ func (c *CLI) pkgDeleteCmd() *cobra.Command {
 				if err != nil {
 					return nil, err
 				}
-				if changed {
-					c.aem.InstanceManager().AwaitStartedOne(instance)
-				}
 				return map[string]any{
 					OutputChanged: changed,
 					"package":     p,
@@ -291,6 +292,10 @@ func (c *CLI) pkgDeleteCmd() *cobra.Command {
 				}, nil
 			})
 			if err != nil {
+				c.Error(err)
+				return
+			}
+			if err := c.aem.InstanceManager().AwaitStarted(InstancesChanged(deleted)); err != nil {
 				c.Error(err)
 				return
 			}
@@ -334,7 +339,6 @@ func (c *CLI) pkgPurgeCmd() *cobra.Command {
 						}
 						if uninstalled {
 							changed = true
-							c.aem.InstanceManager().AwaitStartedOne(instance)
 						}
 					}
 					deleted, err := p.DeleteWithChanged()
@@ -350,6 +354,10 @@ func (c *CLI) pkgPurgeCmd() *cobra.Command {
 				}, nil
 			})
 			if err != nil {
+				c.Error(err)
+				return
+			}
+			if err := c.aem.InstanceManager().AwaitStarted(InstancesChanged(purged)); err != nil {
 				c.Error(err)
 				return
 			}
@@ -385,7 +393,10 @@ func (c *CLI) pkgBuildCmd() *cobra.Command {
 				c.Error(err)
 				return
 			}
-			c.aem.InstanceManager().AwaitStartedOne(*instance)
+			if err := c.aem.InstanceManager().AwaitStartedOne(*instance); err != nil {
+				c.Error(err)
+				return
+			}
 			c.SetOutput("package", p)
 			c.SetOutput("instance", instance)
 			c.Changed("package built")

--- a/cmd/aem/repl.go
+++ b/cmd/aem/repl.go
@@ -102,7 +102,10 @@ func (c *CLI) replAgentSetupCmd() *cobra.Command {
 				return
 			}
 			if changed {
-				c.aem.InstanceManager().AwaitStartedOne(*instance) // TODO if changed restart bundle afterwards (togglable)
+				if err := c.aem.InstanceManager().AwaitStartedOne(*instance); err != nil { // TODO if changed restart bundle afterwards (togglable)
+					c.Error(err)
+					return
+				}
 			}
 			c.SetOutput("replAgent", replAgent)
 			if changed {

--- a/pkg/cfg/defaults.go
+++ b/pkg/cfg/defaults.go
@@ -63,4 +63,9 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("instance.osgi.shutdown_delay", time.Second*3)
 
 	v.SetDefault("instance.crypto.key_bundle_symbolic_name", "com.adobe.granite.crypto.file")
+
+	v.SetDefault("instance.workflow.lib_root", "/libs/settings/workflow/launcher")
+	v.SetDefault("instance.workflow.config_root", "/conf/global/settings/workflow/launcher")
+	v.SetDefault("instance.workflow.toggle_retry_delay", time.Second*10)
+	v.SetDefault("instance.workflow.toggle_retry_timeout", time.Minute*5)
 }

--- a/pkg/cfg/values.go
+++ b/pkg/cfg/values.go
@@ -122,6 +122,7 @@ type ConfigValues struct {
 		Package struct {
 			SnapshotDeploySkipping bool     `mapstructure:"snapshot_deploy_skipping" yaml:"snapshot_deploy_skipping"`
 			SnapshotPatterns       []string `mapstructure:"snapshot_patterns" yaml:"snapshot_patterns"`
+			ToggledWorkflows       []string `mapstructure:"toggled_workflows" yaml:"toggled_workflows"`
 		} `mapstructure:"package" yaml:"package"`
 
 		OSGi struct {

--- a/pkg/cfg/values.go
+++ b/pkg/cfg/values.go
@@ -125,6 +125,13 @@ type ConfigValues struct {
 			ToggledWorkflows       []string `mapstructure:"toggled_workflows" yaml:"toggled_workflows"`
 		} `mapstructure:"package" yaml:"package"`
 
+		Workflow struct {
+			LibRoot            string        `mapstructure:"lib_root" yaml:"lib_root"`
+			ConfigRoot         string        `mapstructure:"config_root" yaml:"lib_root"`
+			ToggleRetryDelay   time.Duration `mapstructure:"toggle_retry_delay" yaml:"toggle_retry_delay"`
+			ToggleRetryTimeout time.Duration `mapstructure:"toggle_retry_timeout" yaml:"toggle_retry_timeout"`
+		} `mapstructure:"workflow" yaml:"workflow"`
+
 		OSGi struct {
 			ShutdownDelay time.Duration `mapstructure:"shutdown_delay" yaml:"shutdown_delay"`
 

--- a/pkg/check.go
+++ b/pkg/check.go
@@ -140,7 +140,7 @@ type EventStableChecker struct {
 }
 
 func (c EventStableChecker) Spec() CheckSpec {
-	return CheckSpec{Mandatory: false}
+	return CheckSpec{Mandatory: true}
 }
 
 func (c EventStableChecker) Check(instance Instance) CheckResult {

--- a/pkg/common/pathx/pathx.go
+++ b/pkg/common/pathx/pathx.go
@@ -189,3 +189,7 @@ func Normalize(path string) string {
 func Canonical(path string) string {
 	return Abs(Normalize(path))
 }
+
+func DirAndFileName(path string) (string, string) {
+	return stringsx.BeforeLast(path, "/"), stringsx.AfterLast(path, "/")
+}

--- a/pkg/instance.go
+++ b/pkg/instance.go
@@ -16,20 +16,20 @@ import (
 
 // Instance represents AEM instance
 type Instance struct {
-	manager *InstanceManager
-
-	local          *LocalInstance
-	http           *HTTP
-	status         *Status
-	repo           *Repo
-	osgi           *OSGi
-	sling          *Sling
-	packageManager *PackageManager
-	crypto         *Crypto
-
+	manager  *InstanceManager
 	id       string
 	user     string
 	password string
+
+	local           *LocalInstance
+	http            *HTTP
+	status          *Status
+	repo            *Repo
+	osgi            *OSGi
+	sling           *Sling
+	crypto          *Crypto
+	packageManager  *PackageManager
+	workflowManager *WorkflowManager
 }
 
 type InstanceState struct {
@@ -94,6 +94,10 @@ func (i Instance) Sling() *Sling {
 
 func (i Instance) PackageManager() *PackageManager {
 	return i.packageManager
+}
+
+func (i Instance) WorkflowManager() *WorkflowManager {
+	return i.workflowManager
 }
 
 func (i Instance) Crypto() *Crypto {

--- a/pkg/instance_manager.go
+++ b/pkg/instance_manager.go
@@ -268,6 +268,9 @@ func configureInstance(inst Instance, config *cfg.Config) {
 	if packageOpts.SnapshotPatterns != nil {
 		inst.packageManager.SnapshotPatterns = packageOpts.SnapshotPatterns
 	}
+	if packageOpts.ToggledWorkflows != nil {
+		inst.packageManager.ToggledWorkflows = packageOpts.ToggledWorkflows
+	}
 
 	statusOpts := instanceOpts.Status
 	inst.status.Timeout = statusOpts.Timeout

--- a/pkg/instance_manager.go
+++ b/pkg/instance_manager.go
@@ -139,6 +139,7 @@ func (im *InstanceManager) New(id, url, user, password string) *Instance {
 	res.status = NewStatus(res)
 	res.repo = NewRepo(res)
 	res.packageManager = NewPackageManager(res)
+	res.workflowManager = NewWorkflowManager(res)
 	res.osgi = NewOSGi(res)
 	res.sling = NewSling(res)
 	res.crypto = NewCrypto(res)

--- a/pkg/instance_manager.go
+++ b/pkg/instance_manager.go
@@ -287,6 +287,12 @@ func configureInstance(inst Instance, config *cfg.Config) {
 
 	cryptoOpts := instanceOpts.Crypto
 	inst.crypto.keyBundleSymbolicName = cryptoOpts.KeyBundleSymbolicName
+
+	workflowOpts := instanceOpts.Workflow
+	inst.workflowManager.LibRoot = workflowOpts.LibRoot
+	inst.workflowManager.ConfigRoot = workflowOpts.ConfigRoot
+	inst.workflowManager.ToggleRetryDelay = workflowOpts.ToggleRetryDelay
+	inst.workflowManager.ToggleRetryTimeout = workflowOpts.ToggleRetryTimeout
 }
 
 func (im *InstanceManager) configureCheckOpts(config *cfg.Config) {

--- a/pkg/local_instance_manager.go
+++ b/pkg/local_instance_manager.go
@@ -199,7 +199,7 @@ func (im *InstanceManager) Start(instances []Instance) ([]Instance, error) {
 			if i.local.IsRunning() && i.local.OutOfDate() {
 				outdated = append(outdated, i)
 
-				log.Infof("%s > is already started but out-of-date", i.ID())
+				log.Infof("%s > already started but out-of-date", i.ID())
 				err := i.local.Stop()
 				if err != nil {
 					return nil, err

--- a/pkg/package_manager.go
+++ b/pkg/package_manager.go
@@ -18,7 +18,7 @@ type PackageManager struct {
 
 	SnapshotDeploySkipping bool
 	SnapshotPatterns       []string
-	WorkflowsDisabled      []string
+	ToggledWorkflows       []string
 }
 
 func NewPackageManager(res *Instance) *PackageManager {
@@ -266,10 +266,9 @@ func (pm *PackageManager) Deploy(localPath string) error {
 	if err != nil {
 		return err
 	}
-	if err := pm.Install(remotePath); err != nil {
-		return err
-	}
-	return nil
+	return pm.instance.workflowManager.ToggleLaunchers(pm.ToggledWorkflows, func() error {
+		return pm.Install(remotePath)
+	})
 }
 
 func (pm *PackageManager) deployLock(file string, checksum string) osx.Lock[packageDeployLock] {

--- a/pkg/package_manager.go
+++ b/pkg/package_manager.go
@@ -18,6 +18,7 @@ type PackageManager struct {
 
 	SnapshotDeploySkipping bool
 	SnapshotPatterns       []string
+	WorkflowsDisabled      []string
 }
 
 func NewPackageManager(res *Instance) *PackageManager {

--- a/pkg/package_manager.go
+++ b/pkg/package_manager.go
@@ -27,6 +27,7 @@ func NewPackageManager(res *Instance) *PackageManager {
 
 		SnapshotDeploySkipping: false,
 		SnapshotPatterns:       []string{"**/*-SNAPSHOT.zip"},
+		ToggledWorkflows:       []string{},
 	}
 }
 

--- a/pkg/pkg/pid.go
+++ b/pkg/pkg/pid.go
@@ -4,6 +4,7 @@ import (
 	"archive/zip"
 	"fmt"
 	"github.com/antchfx/xmlquery"
+	"github.com/samber/lo"
 	"strings"
 )
 
@@ -14,15 +15,19 @@ type PID struct {
 }
 
 func (d PID) String() string {
-	return fmt.Sprintf("%s:%s:%s", d.Group, d.Name, d.Version)
+	return strings.Join(lo.Filter([]string{d.Group, d.Name, d.Version}, func(s string, _ int) bool { return s != "" }), ":")
 }
 
 func ParsePID(str string) (*PID, error) {
 	parts := strings.Split(str, ":")
-	if len(parts) != 3 {
+	switch len(parts) {
+	case 2:
+		return &PID{parts[0], parts[1], ""}, nil
+	case 3:
+		return &PID{parts[0], parts[1], parts[2]}, nil
+	default:
 		return nil, fmt.Errorf("package dependency '%s' has different format than expected 'group:name:version'", str)
 	}
-	return &PID{parts[0], parts[1], parts[2]}, nil
 }
 
 func ReadPIDFromZIP(path string) (*PID, error) {

--- a/pkg/project/app_classic/Taskfile.yml
+++ b/pkg/project/app_classic/Taskfile.yml
@@ -95,8 +95,8 @@ tasks:
         PROPS="
         enabled: true
         transportUri: {{.AEM_PUBLISH_HTTP_URL}}/bin/receive?sling:authRequestLogin=1
-        transportUser: {{ AEM_PUBLISH_USER }}  
-        transportPassword: {{ AEM_PUBLISH_PASSWORD }}  
+        transportUser: {{.AEM_PUBLISH_USER}}  
+        transportPassword: {{.AEM_PUBLISH_PASSWORD}}  
         userId: admin
         "
         echo "$PROPS" | sh aemw repl agent setup -A --location "author" --name "publish"

--- a/pkg/project/app_classic/Taskfile.yml
+++ b/pkg/project/app_classic/Taskfile.yml
@@ -95,8 +95,8 @@ tasks:
         PROPS="
         enabled: true
         transportUri: {{.AEM_PUBLISH_HTTP_URL}}/bin/receive?sling:authRequestLogin=1
-        transportUser: admin
-        transportPassword: admin
+        transportUser: {{ AEM_PUBLISH_USER }}  
+        transportPassword: {{ AEM_PUBLISH_PASSWORD }}  
         userId: admin
         "
         echo "$PROPS" | sh aemw repl agent setup -A --location "author" --name "publish"

--- a/pkg/project/app_classic/aem/default/etc/aem.yml
+++ b/pkg/project/app_classic/aem/default/etc/aem.yml
@@ -8,8 +8,8 @@ instance:
   config:
     local_author:
       http_url: [[.Env.AEM_AUTHOR_HTTP_URL | default "http://127.0.0.1:4502" ]]
-      user: admin
-      password: admin
+      user: [[.Env.AEM_AUTHOR_USER | default "admin" ]]
+      password: [[.Env.AEM_AUTHOR_PASSWORD | default "admin" ]]
       run_modes: [ local ]
       jvm_opts:
         - -server
@@ -27,8 +27,8 @@ instance:
       sling_props: []
     local_publish:
       http_url: [[.Env.AEM_PUBLISH_HTTP_URL | default "http://127.0.0.1:4503" ]]
-      user: admin
-      password: admin
+      user: [[.Env.AEM_PUBLISH_USER | default "admin" ]]
+      password: [[.Env.AEM_PUBLISH_PASSWORD | default "admin" ]]
       run_modes: [ local ]
       jvm_opts:
         - -server
@@ -134,6 +134,9 @@ instance:
     snapshot_patterns: [ "**/*-SNAPSHOT.zip" ]
     # Use checksums to avoid re-deployments when snapshot AEM packages are unchanged
     snapshot_deploy_skipping: true
+    # Disable following workflow for a package deployment time only
+    workflows_disabled:
+      - /blabla
 
   # OSGi Framework
   osgi:

--- a/pkg/project/app_classic/aem/default/etc/aem.yml
+++ b/pkg/project/app_classic/aem/default/etc/aem.yml
@@ -136,7 +136,7 @@ instance:
     snapshot_deploy_skipping: true
     # Disable following workflow for a package deployment time only
     workflows_disabled:
-      - /blabla
+      - /libs/settings/workflow/launcher/config/update_asset_* # /conf/global/settings/workflow/launcher/config/update_asset_*
 
   # OSGi Framework
   osgi:

--- a/pkg/project/app_classic/aem/default/etc/aem.yml
+++ b/pkg/project/app_classic/aem/default/etc/aem.yml
@@ -135,8 +135,8 @@ instance:
     # Use checksums to avoid re-deployments when snapshot AEM packages are unchanged
     snapshot_deploy_skipping: true
     # Disable following workflow for a package deployment time only
-    workflows_disabled:
-      - /libs/settings/workflow/launcher/config/update_asset_* # /conf/global/settings/workflow/launcher/config/update_asset_*
+    toggled_workflows:
+      - /libs/settings/workflow/launcher/config/update_asset_*
 
   # OSGi Framework
   osgi:

--- a/pkg/project/app_classic/aem/default/etc/aem.yml
+++ b/pkg/project/app_classic/aem/default/etc/aem.yml
@@ -134,9 +134,8 @@ instance:
     snapshot_patterns: [ "**/*-SNAPSHOT.zip" ]
     # Use checksums to avoid re-deployments when snapshot AEM packages are unchanged
     snapshot_deploy_skipping: true
-    # Disable following workflow for a package deployment time only
-    toggled_workflows:
-      - /libs/settings/workflow/launcher/config/update_asset_*
+    # Disable following workflow launchers for a package deployment time only
+    toggled_workflows: [/libs/settings/workflow/launcher/config/update_asset_*,/libs/settings/workflow/launcher/config/dam_*]
 
   # OSGi Framework
   osgi:

--- a/pkg/project/app_cloud/Taskfile.yml
+++ b/pkg/project/app_cloud/Taskfile.yml
@@ -94,8 +94,8 @@ tasks:
         PROPS="
         enabled: true
         transportUri: {{.AEM_PUBLISH_HTTP_URL}}/bin/receive?sling:authRequestLogin=1
-        transportUser: admin
-        transportPassword: admin
+        transportUser: {{.AEM_PUBLISH_USER}}  
+        transportPassword: {{.AEM_PUBLISH_PASSWORD}}  
         userId: admin
         "
         echo "$PROPS" | sh aemw repl agent setup -A --location "author" --name "publish"

--- a/pkg/project/app_cloud/aem/default/etc/aem.yml
+++ b/pkg/project/app_cloud/aem/default/etc/aem.yml
@@ -136,8 +136,7 @@ instance:
     snapshot_deploy_skipping: true
     # Disable following workflow for a package deployment time only
     workflows_disabled:
-      - /libs/settings/workflow/launcher/config/asset_processing_on_sdk_create # /conf/global/settings/workflow/launcher/config/asset_processing_on_sdk_create
-      - /libs/settings/workflow/launcher/config/asset_processing_on_sdk_mod # /conf/global/settings/workflow/launcher/config/asset_processing_on_sdk_mod
+      - /libs/settings/workflow/launcher/config/asset_processing_on_sdk_* # /conf/global/settings/workflow/launcher/config/asset_processing_on_sdk_*
 
   # OSGi Framework
   osgi:

--- a/pkg/project/app_cloud/aem/default/etc/aem.yml
+++ b/pkg/project/app_cloud/aem/default/etc/aem.yml
@@ -8,8 +8,8 @@ instance:
   config:
     local_author:
       http_url: [[.Env.AEM_AUTHOR_HTTP_URL | default "http://127.0.0.1:4502" ]]
-      user: admin
-      password: admin
+      user: [[.Env.AEM_AUTHOR_USER | default "admin" ]]
+      password: [[.Env.AEM_AUTHOR_PASSWORD | default "admin" ]]
       run_modes: [ local ]
       jvm_opts:
         - -server
@@ -27,8 +27,8 @@ instance:
       sling_props: []
     local_publish:
       http_url: [[.Env.AEM_PUBLISH_HTTP_URL | default "http://127.0.0.1:4503" ]]
-      user: admin
-      password: admin
+      user: [[.Env.AEM_PUBLISH_USER | default "admin" ]]
+      password: [[.Env.AEM_PUBLISH_PASSWORD | default "admin" ]]
       run_modes: [ local ]
       jvm_opts:
         - -server
@@ -134,6 +134,10 @@ instance:
     snapshot_patterns: [ "**/*-SNAPSHOT.zip" ]
     # Use checksums to avoid re-deployments when snapshot AEM packages are unchanged
     snapshot_deploy_skipping: true
+    # Disable following workflow for a package deployment time only
+    workflows_disabled:
+      - /libs/settings/workflow/launcher/config/asset_processing_on_sdk_create # /conf/global/settings/workflow/launcher/config/asset_processing_on_sdk_create
+      - /libs/settings/workflow/launcher/config/asset_processing_on_sdk_mod # /conf/global/settings/workflow/launcher/config/asset_processing_on_sdk_mod
 
   # OSGi Framework
   osgi:

--- a/pkg/project/app_cloud/aem/default/etc/aem.yml
+++ b/pkg/project/app_cloud/aem/default/etc/aem.yml
@@ -134,9 +134,9 @@ instance:
     snapshot_patterns: [ "**/*-SNAPSHOT.zip" ]
     # Use checksums to avoid re-deployments when snapshot AEM packages are unchanged
     snapshot_deploy_skipping: true
-    # Disable following workflow for a package deployment time only
-    workflows_disabled:
-      - /libs/settings/workflow/launcher/config/asset_processing_on_sdk_* # /conf/global/settings/workflow/launcher/config/asset_processing_on_sdk_*
+    # Disable following workflows for a package deployment time only
+    toggled_workflows:
+      - /libs/settings/workflow/launcher/config/asset_processing_on_sdk_*
 
   # OSGi Framework
   osgi:

--- a/pkg/project/app_cloud/aem/default/etc/aem.yml
+++ b/pkg/project/app_cloud/aem/default/etc/aem.yml
@@ -134,9 +134,8 @@ instance:
     snapshot_patterns: [ "**/*-SNAPSHOT.zip" ]
     # Use checksums to avoid re-deployments when snapshot AEM packages are unchanged
     snapshot_deploy_skipping: true
-    # Disable following workflows for a package deployment time only
-    toggled_workflows:
-      - /libs/settings/workflow/launcher/config/asset_processing_on_sdk_*
+    # Disable following workflow launchers for a package deployment time only
+    toggled_workflows: [/libs/settings/workflow/launcher/config/asset_processing_on_sdk_*,/libs/settings/workflow/launcher/config/dam_*]
 
   # OSGi Framework
   osgi:

--- a/pkg/project/instance/Taskfile.yml
+++ b/pkg/project/instance/Taskfile.yml
@@ -73,8 +73,8 @@ tasks:
         PROPS="
         enabled: true
         transportUri: {{.AEM_PUBLISH_HTTP_URL}}/bin/receive?sling:authRequestLogin=1
-        transportUser: admin
-        transportPassword: admin
+        transportUser: {{.AEM_PUBLISH_USER}}  
+        transportPassword: {{.AEM_PUBLISH_PASSWORD}}  
         userId: admin
         "
         echo "$PROPS" | sh aemw repl agent setup -A --location "author" --name "publish"

--- a/pkg/project/instance/aem/default/etc/aem.yml
+++ b/pkg/project/instance/aem/default/etc/aem.yml
@@ -8,8 +8,8 @@ instance:
   config:
     local_author:
       http_url: [[.Env.AEM_AUTHOR_HTTP_URL | default "http://127.0.0.1:4502" ]]
-      user: admin
-      password: admin
+      user: [[.Env.AEM_AUTHOR_USER | default "admin" ]]
+      password: [[.Env.AEM_AUTHOR_PASSWORD | default "admin" ]]
       run_modes: [ local ]
       jvm_opts:
         - -server
@@ -27,8 +27,8 @@ instance:
       sling_props: []
     local_publish:
       http_url: [[.Env.AEM_PUBLISH_HTTP_URL | default "http://127.0.0.1:4503" ]]
-      user: admin
-      password: admin
+      user: [[.Env.AEM_PUBLISH_USER | default "admin" ]]
+      password: [[.Env.AEM_PUBLISH_PASSWORD | default "admin" ]]
       run_modes: [ local ]
       jvm_opts:
         - -server
@@ -134,6 +134,8 @@ instance:
     snapshot_patterns: [ "**/*-SNAPSHOT.zip" ]
     # Use checksums to avoid re-deployments when snapshot AEM packages are unchanged
     snapshot_deploy_skipping: true
+    # Disable following workflow launchers for a package deployment time only
+    toggled_workflows: [/libs/settings/workflow/launcher/config/asset_processing_on_sdk_*,/libs/settings/workflow/launcher/config/update_asset_*,/libs/settings/workflow/launcher/config/dam_*]
 
   # OSGi Framework
   osgi:

--- a/pkg/repo.go
+++ b/pkg/repo.go
@@ -91,6 +91,26 @@ func (r Repo) Delete(path string) error {
 	return nil
 }
 
+func (r Repo) Copy(sourcePath string, targetPath string) error {
+	log.Infof("%s > copying node from '%s' to '%s'", r.instance.ID(), sourcePath, targetPath)
+	resp, err := r.requestFormData("copy", map[string]any{":dest": targetPath}).Post(sourcePath)
+	if err = r.handleResponse(fmt.Sprintf("%s > cannot copy node from '%s' to '%s'", r.instance.ID(), sourcePath, targetPath), resp, err); err != nil {
+		return err
+	}
+	log.Infof("%s > copied node from '%s' to '%s'", r.instance.ID(), sourcePath, targetPath)
+	return nil
+}
+
+func (r Repo) Move(sourcePath string, targetPath string, replace bool) error {
+	log.Infof("%s > moving node from '%s' to '%s'", r.instance.ID(), sourcePath, targetPath)
+	resp, err := r.requestFormData("move", map[string]any{":dest": targetPath, ":replace": replace}).Post(sourcePath)
+	if err = r.handleResponse(fmt.Sprintf("%s > cannot move node from '%s' to '%s'", r.instance.ID(), sourcePath, targetPath), resp, err); err != nil {
+		return err
+	}
+	log.Infof("%s > moved node from '%s' to '%s'", r.instance.ID(), sourcePath, targetPath)
+	return nil
+}
+
 func (r Repo) requestFormData(operation string, props map[string]any) *resty.Request {
 	request := r.instance.http.Request()
 	request.SetHeader("Accept", "application/json")

--- a/pkg/repo_int_test.go
+++ b/pkg/repo_int_test.go
@@ -87,7 +87,7 @@ func TestRepoTraverse(t *testing.T) {
 	aem := pkg.NewAem()
 
 	instance := aem.InstanceManager().NewLocalAuthor()
-	it := instance.Repo().Node("/etc/dam").Traverse()
+	it := instance.Repo().Node("/etc/dam").Traversor()
 
 	traversed := 0
 	for {

--- a/pkg/repo_node.go
+++ b/pkg/repo_node.go
@@ -226,8 +226,16 @@ func (n RepoNode) Copy(targetPath string) error {
 	return nil // TODO impl this
 }
 
+func (n RepoNode) CopyWithChanged(targetPath string) (bool, error) {
+	return false, nil
+}
+
 func (n RepoNode) Move(targetPath string, replace bool) error {
 	return nil // TODO impl this
+}
+
+func (n RepoNode) MoveWithChanged(targetPath string, replace bool) (bool, error) {
+	return false, nil
 }
 
 func (n RepoNode) String() string {
@@ -261,7 +269,7 @@ func (n RepoNode) MarshalText() string {
 	return sb.String()
 }
 
-func (n RepoNode) Traverse() RepoNodeTraversor {
+func (n RepoNode) Traversor() RepoNodeTraversor {
 	return RepoNodeTraversor{nodes: langx.NewStackWithValue(n)}
 }
 

--- a/pkg/repo_node.go
+++ b/pkg/repo_node.go
@@ -128,7 +128,7 @@ type RepoNodeState struct {
 }
 
 func (n RepoNode) State() (*RepoNodeState, error) {
-	exists, err := n.ReadExists()
+	exists, err := n.Exists()
 	if err != nil {
 		return nil, err
 	}
@@ -149,7 +149,7 @@ func (n RepoNode) State() (*RepoNodeState, error) {
 	}, nil
 }
 
-func (n RepoNode) ReadExists() (bool, error) {
+func (n RepoNode) Exists() (bool, error) {
 	return n.repo.Exists(n.path)
 }
 
@@ -189,7 +189,7 @@ func (n RepoNode) SaveWithChanged(props map[string]any) (bool, error) {
 }
 
 func (n RepoNode) DeleteWithChanged() (bool, error) {
-	exists, err := n.ReadExists()
+	exists, err := n.Exists()
 	if err != nil {
 		return false, err
 	}
@@ -204,7 +204,7 @@ func (n RepoNode) DeleteWithChanged() (bool, error) {
 }
 
 func (n RepoNode) Delete() error {
-	exists, err := n.ReadExists()
+	exists, err := n.Exists()
 	if err != nil {
 		return err
 	}

--- a/pkg/repo_node.go
+++ b/pkg/repo_node.go
@@ -222,6 +222,14 @@ func (n RepoNode) SaveProp(name string, value any) error {
 	return n.repo.Save(n.path, map[string]any{name: value})
 }
 
+func (n RepoNode) Copy(targetPath string) error {
+	return nil // TODO impl this
+}
+
+func (n RepoNode) Move(targetPath string, replace bool) error {
+	return nil // TODO impl this
+}
+
 func (n RepoNode) String() string {
 	return fmt.Sprintf("node '%s'", n.path)
 }

--- a/pkg/workflow.go
+++ b/pkg/workflow.go
@@ -2,6 +2,8 @@ package pkg
 
 import (
 	"fmt"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cast"
 	"strings"
 )
 
@@ -17,6 +19,70 @@ func (l WorkflowLauncher) LibNode() RepoNode {
 
 func (l WorkflowLauncher) ConfigNode() RepoNode {
 	return l.manager.instance.repo.Node(strings.ReplaceAll(l.path, WorkflowLauncherLibRoot+"/", WorkflowLauncherConfigRoot+"/"))
+}
+
+func (l WorkflowLauncher) Prepare() error {
+	configNode := l.ConfigNode()
+	libNode := l.LibNode()
+	configExists, err := configNode.Exists()
+	if err != nil {
+		return fmt.Errorf("%s > cannot read workflow launcher config '%s': %w", l.manager.instance.ID(), configNode.path, err)
+	}
+	if !configExists {
+		if err := libNode.Copy(configNode.Path()); err != nil {
+			return fmt.Errorf("%s > workflow launcher config node '%s' cannot be copied from lib node '%s': %s", l.manager.instance.ID(), configNode.path, libNode.path, err)
+		}
+	}
+	return nil
+}
+
+func (l WorkflowLauncher) Disable() error {
+	node := l.ConfigNode()
+	if err := node.Save(map[string]any{
+		WorkflowLauncherEnabledProp: false,
+		WorkflowLauncherToggledProp: true,
+	}); err != nil {
+		return fmt.Errorf("%s > cannot disable workflow launcher '%s': %w", l.manager.instance.ID(), node.path, err)
+	}
+	log.Infof("%s > disabled workflow launcher '%s'", l.manager.instance.ID(), node.path)
+	return nil
+}
+
+func (l WorkflowLauncher) Enable() error {
+	node := l.ConfigNode()
+	if err := node.Save(map[string]any{
+		WorkflowLauncherEnabledProp: true,
+		WorkflowLauncherToggledProp: nil,
+	}); err != nil {
+		return fmt.Errorf("%s > cannot enable workflow launcher '%s': %w", l.manager.instance.ID(), node.path, err)
+	}
+	log.Infof("%s > enabled workflow launcher '%s'", l.manager.instance.ID(), node.path)
+	return nil
+}
+
+func (l WorkflowLauncher) IsEnabled() (bool, error) {
+	configNode := l.ConfigNode()
+	configState, err := configNode.State()
+	if err != nil {
+		return false, fmt.Errorf("%s > cannot read workflow launcher config just copied '%s': %w", l.manager.instance.ID(), configNode.path, err)
+	}
+	enabledAny, enabledFound := configState.Properties[WorkflowLauncherEnabledProp]
+	enabled := enabledFound && cast.ToBool(enabledAny)
+	return enabled, nil
+}
+
+func (l WorkflowLauncher) IsToggled() (bool, error) {
+	configNode := l.ConfigNode()
+	configState, err := configNode.State()
+	if err != nil {
+		return false, fmt.Errorf("%s > cannot read config of workflow launcher '%s': %w", l.manager.instance.ID(), configNode.path, err)
+	}
+	if !configState.Exists {
+		return false, fmt.Errorf("%s > config node of workflow launcher does not exist '%s': %w", l.manager.instance.ID(), configNode.path, err)
+	}
+	toggledAny, toggledFound := configState.Properties[WorkflowLauncherToggledProp]
+	toggled := toggledFound && cast.ToBool(toggledAny)
+	return toggled, nil
 }
 
 func (l WorkflowLauncher) String() string {

--- a/pkg/workflow.go
+++ b/pkg/workflow.go
@@ -1,0 +1,89 @@
+package pkg
+
+import (
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"strings"
+)
+
+type WorkflowLauncher struct {
+	manager *WorkflowManager
+
+	path string
+}
+
+type WorkflowLauncherState struct {
+	Properties map[string]any
+
+	Path   string `yaml:"path" json:"path"`
+	Exists bool   `yaml:"exists" json:"exists"`
+}
+
+func (l WorkflowLauncher) LibNode() RepoNode {
+	return l.manager.instance.repo.Node(l.path)
+}
+
+func (l WorkflowLauncher) ConfigNode() RepoNode {
+	return l.manager.instance.repo.Node(strings.ReplaceAll(l.path, WorkflowLauncherLibRoot+"/", WorkflowLauncherConfigRoot+"/"))
+}
+
+func (l WorkflowLauncher) State() (*RepoNodeState, error) {
+	return l.LibNode().State()
+}
+
+func (l WorkflowLauncher) Enable() (bool, error) {
+	return l.Toggle(true)
+}
+
+func (l WorkflowLauncher) Disable() (bool, error) {
+	return l.Toggle(false)
+}
+
+func (l WorkflowLauncher) Toggle(flag bool) (bool, error) {
+	configNode := l.ConfigNode()
+	configNodeExists, err := configNode.ReadExists()
+	if err != nil {
+		return false, err
+	}
+	if !configNodeExists {
+		if err := l.LibNode().Copy(configNode.Path()); err != nil {
+			return false, err
+		}
+	}
+	state, err := configNode.State()
+	if err != nil {
+		return false, err
+	}
+	flagCurrentAny, ok := state.Properties[WorkflowLauncherEnabledProp]
+	flagChangeNeeded := true
+	if ok {
+		flagChangeNeeded = flagCurrentAny.(bool) != flag
+	}
+	if !flagChangeNeeded {
+		return false, nil
+	}
+	if flag {
+		log.Infof("%s > enabling workflow launcher '%s'", l.manager.instance.ID(), l.path)
+	} else {
+		log.Infof("%s > disabling workflow launcher '%s'", l.manager.instance.ID(), l.path)
+	}
+	if err := configNode.SaveProp(WorkflowLauncherEnabledProp, flag); err != nil {
+		return false, err
+	}
+	if flag {
+		log.Infof("%s > enabled workflow launcher '%s'", l.manager.instance.ID(), l.path)
+	} else {
+		log.Infof("%s > disabled workflow launcher '%s'", l.manager.instance.ID(), l.path)
+	}
+	return true, nil
+}
+
+func (l WorkflowLauncher) String() string {
+	return fmt.Sprintf("workflow launcher '%s'", l.path)
+}
+
+const (
+	WorkflowLauncherLibRoot     = "/libs/settings/workflow/launcher"
+	WorkflowLauncherConfigRoot  = "/conf/global/settings/workflow/launcher"
+	WorkflowLauncherEnabledProp = "enabled"
+)

--- a/pkg/workflow.go
+++ b/pkg/workflow.go
@@ -2,7 +2,6 @@ package pkg
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
 	"strings"
 )
 
@@ -20,61 +19,11 @@ func (l WorkflowLauncher) ConfigNode() RepoNode {
 	return l.manager.instance.repo.Node(strings.ReplaceAll(l.path, WorkflowLauncherLibRoot+"/", WorkflowLauncherConfigRoot+"/"))
 }
 
-func (l WorkflowLauncher) State() (*RepoNodeState, error) {
-	return l.LibNode().State()
-}
-
-func (l WorkflowLauncher) Enable() (bool, error) {
-	return l.Toggle(true)
-}
-
-func (l WorkflowLauncher) Disable() (bool, error) {
-	return l.Toggle(false)
-}
-
-func (l WorkflowLauncher) Toggle(flag bool) (bool, error) {
-	configNode := l.ConfigNode()
-	configNodeExists, err := configNode.ReadExists()
-	if err != nil {
-		return false, err
-	}
-	if !configNodeExists {
-		if err := l.LibNode().Copy(configNode.Path()); err != nil {
-			return false, err
-		}
-	}
-	state, err := configNode.State()
-	if err != nil {
-		return false, err
-	}
-	flagCurrentAny, ok := state.Properties[WorkflowLauncherEnabledProp]
-	flagChangeNeeded := true
-	if ok {
-		flagChangeNeeded = flagCurrentAny.(bool) != flag
-	}
-	if !flagChangeNeeded {
-		return false, nil
-	}
-	if flag {
-		log.Infof("%s > enabling workflow launcher '%s'", l.manager.instance.ID(), l.path)
-	} else {
-		log.Infof("%s > disabling workflow launcher '%s'", l.manager.instance.ID(), l.path)
-	}
-	if err := configNode.SaveProp(WorkflowLauncherEnabledProp, flag); err != nil {
-		return false, err
-	}
-	if flag {
-		log.Infof("%s > enabled workflow launcher '%s'", l.manager.instance.ID(), l.path)
-	} else {
-		log.Infof("%s > disabled workflow launcher '%s'", l.manager.instance.ID(), l.path)
-	}
-	return true, nil
-}
-
 func (l WorkflowLauncher) String() string {
 	return fmt.Sprintf("workflow launcher '%s'", l.path)
 }
 
 const (
 	WorkflowLauncherEnabledProp = "enabled"
+	WorkflowLauncherToggledProp = "toggled"
 )

--- a/pkg/workflow.go
+++ b/pkg/workflow.go
@@ -12,13 +12,6 @@ type WorkflowLauncher struct {
 	path string
 }
 
-type WorkflowLauncherState struct {
-	Properties map[string]any
-
-	Path   string `yaml:"path" json:"path"`
-	Exists bool   `yaml:"exists" json:"exists"`
-}
-
 func (l WorkflowLauncher) LibNode() RepoNode {
 	return l.manager.instance.repo.Node(l.path)
 }
@@ -83,7 +76,5 @@ func (l WorkflowLauncher) String() string {
 }
 
 const (
-	WorkflowLauncherLibRoot     = "/libs/settings/workflow/launcher"
-	WorkflowLauncherConfigRoot  = "/conf/global/settings/workflow/launcher"
 	WorkflowLauncherEnabledProp = "enabled"
 )

--- a/pkg/workflow_manager.go
+++ b/pkg/workflow_manager.go
@@ -10,7 +10,7 @@ type WorkflowManager struct {
 func NewWorkflowManager(i *Instance) *WorkflowManager {
 	return &WorkflowManager{
 		instance: i,
-		
+
 		libRoot:    WorkflowLauncherLibRoot,
 		configRoot: WorkflowLauncherConfigRoot,
 	}

--- a/pkg/workflow_manager.go
+++ b/pkg/workflow_manager.go
@@ -1,5 +1,7 @@
 package pkg
 
+import log "github.com/sirupsen/logrus"
+
 type WorkflowManager struct {
 	instance *Instance
 
@@ -18,6 +20,31 @@ func NewWorkflowManager(i *Instance) *WorkflowManager {
 
 func (w *WorkflowManager) Launcher(path string) *WorkflowLauncher {
 	return &WorkflowLauncher{manager: w, path: path}
+}
+
+func (w *WorkflowManager) ToggleLaunchers(libPaths []string, action func() error) error {
+	all := w.FindLaunchers(libPaths)
+	var disabled []WorkflowLauncher
+	for _, launcher := range all {
+		_, err := launcher.Disable()
+		if err == nil {
+			disabled = append(disabled, launcher)
+		} else {
+			log.Warnf("%s > workflow launcher '%s' cannot be temporarily disabled", w.instance.ID(), launcher.path)
+		}
+	}
+	defer func() {
+		for _, launcher := range disabled {
+			if _, err := launcher.Enable(); err != nil {
+				log.Warnf("%s > workflow launcher '%s' temporarily disabled cannot be reenabled", w.instance.ID(), launcher.path)
+			}
+		}
+	}()
+	return action()
+}
+
+func (w *WorkflowManager) FindLaunchers(paths []string) []WorkflowLauncher {
+	return nil // TODO impl this
 }
 
 const (

--- a/pkg/workflow_manager.go
+++ b/pkg/workflow_manager.go
@@ -34,6 +34,7 @@ func (w *WorkflowManager) ToggleLaunchers(libPaths []string, action func() error
 		}
 	}
 	defer func() {
+		// TODO add retry mechanism until done
 		for _, launcher := range disabled {
 			if _, err := launcher.Enable(); err != nil {
 				log.Warnf("%s > workflow launcher '%s' temporarily disabled cannot be reenabled", w.instance.ID(), launcher.path)

--- a/pkg/workflow_manager.go
+++ b/pkg/workflow_manager.go
@@ -91,11 +91,15 @@ func (w *WorkflowManager) disableLauncher(launcher WorkflowLauncher) error {
 	libNode := launcher.LibNode()
 	configState, err := configNode.State()
 	if err != nil {
-		return fmt.Errorf("%s > workflow launcher config state cannot be read '%s'", w.instance.ID(), err)
+		return fmt.Errorf("%s > cannot read workflow launcher config '%s': %w", w.instance.ID(), configNode.path, err)
 	}
 	if !configState.Exists {
 		if err := libNode.Copy(configNode.Path()); err != nil {
 			return fmt.Errorf("%s > workflow launcher config node '%s' cannot be copied from lib node '%s': %s", w.instance.ID(), configNode.path, libNode.path, err)
+		}
+		configState, err = configNode.State()
+		if err != nil {
+			return fmt.Errorf("%s > cannot read workflow launcher config just copied '%s': %w", w.instance.ID(), configNode.path, err)
 		}
 	}
 	enabledAny, enabledFound := configState.Properties[WorkflowLauncherEnabledProp]
@@ -105,9 +109,9 @@ func (w *WorkflowManager) disableLauncher(launcher WorkflowLauncher) error {
 			WorkflowLauncherEnabledProp: false,
 			WorkflowLauncherToggledProp: true,
 		}); err != nil {
-			return fmt.Errorf("%s > workflow launcher '%s' cannot be disabled: %s", w.instance.ID(), configNode.path, err)
+			return fmt.Errorf("%s > cannot disable workflow launcher '%s': %w", w.instance.ID(), configNode.path, err)
 		}
-		log.Infof("%s > workflow launcher '%s' disabled", w.instance.ID(), configNode.path)
+		log.Infof("%s > disabled workflow launcher '%s'", w.instance.ID(), configNode.path)
 	}
 	return nil
 }
@@ -127,10 +131,10 @@ func (w *WorkflowManager) enableLauncher(launcher WorkflowLauncher) error {
 	configNode := launcher.ConfigNode()
 	configState, err := configNode.State()
 	if err != nil {
-		return fmt.Errorf("%s > workflow launcher config cannot be read: %w", w.instance.ID(), err)
+		return fmt.Errorf("%s > cannot read config of workflow launcher '%s': %w", w.instance.ID(), configNode.path, err)
 	}
 	if !configState.Exists {
-		return fmt.Errorf("%s > workflow launcher config does not exist: %w", w.instance.ID(), err)
+		return fmt.Errorf("%s > config node of workflow launcher does not exist '%s': %w", w.instance.ID(), configNode.path, err)
 	}
 	toggledAny, toggledFound := configState.Properties[WorkflowLauncherToggledProp]
 	toggled := toggledFound && cast.ToBool(toggledAny)
@@ -139,9 +143,9 @@ func (w *WorkflowManager) enableLauncher(launcher WorkflowLauncher) error {
 			WorkflowLauncherEnabledProp: true,
 			WorkflowLauncherToggledProp: nil,
 		}); err != nil {
-			return fmt.Errorf("%s > workflow launcher '%s' cannot be disabled: %s", w.instance.ID(), configNode.path, err)
+			return fmt.Errorf("%s > cannot enable workflow launcher '%s': %w", w.instance.ID(), configNode.path, err)
 		}
-		log.Infof("%s > workflow launcher '%s' disabled", w.instance.ID(), configNode.path)
+		log.Infof("%s > enabled workflow launcher '%s'", w.instance.ID(), configNode.path)
 	}
 	return nil
 }

--- a/pkg/workflow_manager.go
+++ b/pkg/workflow_manager.go
@@ -2,12 +2,25 @@ package pkg
 
 type WorkflowManager struct {
 	instance *Instance
+
+	libRoot    string
+	configRoot string
 }
 
 func NewWorkflowManager(i *Instance) *WorkflowManager {
-	return &WorkflowManager{instance: i}
+	return &WorkflowManager{
+		instance: i,
+		
+		libRoot:    WorkflowLauncherLibRoot,
+		configRoot: WorkflowLauncherConfigRoot,
+	}
 }
 
 func (w *WorkflowManager) Launcher(path string) *WorkflowLauncher {
 	return &WorkflowLauncher{manager: w, path: path}
 }
+
+const (
+	WorkflowLauncherLibRoot    = "/libs/settings/workflow/launcher"
+	WorkflowLauncherConfigRoot = "/conf/global/settings/workflow/launcher"
+)

--- a/pkg/workflow_manager.go
+++ b/pkg/workflow_manager.go
@@ -1,6 +1,12 @@
 package pkg
 
-import log "github.com/sirupsen/logrus"
+import (
+	"fmt"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cast"
+	"github.com/wttech/aemc/pkg/common/pathx"
+	"github.com/wttech/aemc/pkg/common/stringsx"
+)
 
 type WorkflowManager struct {
 	instance *Instance
@@ -23,29 +29,98 @@ func (w *WorkflowManager) Launcher(path string) *WorkflowLauncher {
 }
 
 func (w *WorkflowManager) ToggleLaunchers(libPaths []string, action func() error) error {
-	all := w.FindLaunchers(libPaths)
-	var disabled []WorkflowLauncher
-	for _, launcher := range all {
-		_, err := launcher.Disable() // TODO store info about 'managed by aemc'; to know which one to restore
-		if err == nil {
-			disabled = append(disabled, launcher)
-		} else {
-			log.Warnf("%s > workflow launcher '%s' cannot be temporarily disabled", w.instance.ID(), launcher.path)
-		}
+	launchers, err := w.findLaunchers(libPaths)
+	if err != nil {
+		return err
 	}
-	defer func() {
-		// TODO add retry mechanism until done
-		for _, launcher := range disabled {
-			if _, err := launcher.Enable(); err != nil {
-				log.Warnf("%s > workflow launcher '%s' temporarily disabled cannot be reenabled", w.instance.ID(), launcher.path)
-			}
-		}
-	}()
+	defer func(launchers []WorkflowLauncher) { w.enableLaunchers(launchers) }(launchers)
+	w.disableLaunchers(launchers)
 	return action()
 }
 
-func (w *WorkflowManager) FindLaunchers(paths []string) []WorkflowLauncher {
-	return nil // TODO impl this
+func (w *WorkflowManager) findLaunchers(paths []string) ([]WorkflowLauncher, error) {
+	var result []WorkflowLauncher
+	for _, libPath := range paths {
+		dir, fileName := pathx.DirAndFileName(libPath)
+		dirNode := w.instance.repo.Node(dir)
+		children, err := dirNode.Children()
+		if err != nil {
+			return nil, err
+		}
+		for _, child := range children {
+			if stringsx.Match(child.Name(), fileName) {
+				result = append(result, *(w.Launcher(child.Path())))
+			}
+		}
+	}
+	return result, nil
+}
+
+func (w *WorkflowManager) disableLaunchers(launchers []WorkflowLauncher) {
+	for _, launcher := range launchers {
+		if err := w.disableLauncher(launcher); err != nil {
+			log.Warnf("%s", err)
+			continue
+		}
+	}
+}
+
+func (w *WorkflowManager) disableLauncher(launcher WorkflowLauncher) error {
+	configNode := launcher.ConfigNode()
+	libNode := launcher.LibNode()
+	configState, err := configNode.State()
+	if err != nil {
+		return fmt.Errorf("%s > workflow launcher config state cannot be read '%s'", w.instance.ID(), err)
+	}
+	if !configState.Exists {
+		if err := libNode.Copy(configNode.Path()); err != nil {
+			return fmt.Errorf("%s > workflow launcher config node '%s' cannot be copied from lib node '%s': %s", w.instance.ID(), configNode.path, libNode.path, err)
+		}
+	}
+	enabledAny, enabledFound := configState.Properties[WorkflowLauncherEnabledProp]
+	enabled := enabledFound && cast.ToBool(enabledAny)
+	if enabled {
+		if err := configNode.Save(map[string]any{
+			WorkflowLauncherEnabledProp: false,
+			WorkflowLauncherToggledProp: true,
+		}); err != nil {
+			return fmt.Errorf("%s > workflow launcher '%s' cannot be disabled: %s", w.instance.ID(), configNode.path, err)
+		}
+		log.Infof("%s > workflow launcher '%s' disabled", w.instance.ID(), configNode.path)
+	}
+	return nil
+}
+
+func (w *WorkflowManager) enableLaunchers(launchers []WorkflowLauncher) {
+	for _, launcher := range launchers {
+		if err := w.enableLauncher(launcher); err != nil {
+			log.Warnf("%s", err)
+			continue
+		}
+	}
+}
+
+func (w *WorkflowManager) enableLauncher(launcher WorkflowLauncher) error {
+	configNode := launcher.ConfigNode()
+	configState, err := configNode.State()
+	if err != nil {
+		return fmt.Errorf("%s > workflow launcher config cannot be read: %w", w.instance.ID(), err)
+	}
+	if !configState.Exists {
+		return fmt.Errorf("%s > workflow launcher config does not exist: %w", w.instance.ID(), err)
+	}
+	toggledAny, toggledFound := configState.Properties[WorkflowLauncherToggledProp]
+	toggled := toggledFound && cast.ToBool(toggledAny)
+	if toggled {
+		if err := configNode.Save(map[string]any{
+			WorkflowLauncherEnabledProp: true,
+			WorkflowLauncherToggledProp: nil,
+		}); err != nil {
+			return fmt.Errorf("%s > workflow launcher '%s' cannot be disabled: %s", w.instance.ID(), configNode.path, err)
+		}
+		log.Infof("%s > workflow launcher '%s' disabled", w.instance.ID(), configNode.path)
+	}
+	return nil
 }
 
 const (

--- a/pkg/workflow_manager.go
+++ b/pkg/workflow_manager.go
@@ -26,7 +26,7 @@ func (w *WorkflowManager) ToggleLaunchers(libPaths []string, action func() error
 	all := w.FindLaunchers(libPaths)
 	var disabled []WorkflowLauncher
 	for _, launcher := range all {
-		_, err := launcher.Disable()
+		_, err := launcher.Disable() // TODO store info about 'managed by aemc'; to know which one to restore
 		if err == nil {
 			disabled = append(disabled, launcher)
 		} else {

--- a/pkg/workflow_manager.go
+++ b/pkg/workflow_manager.go
@@ -1,0 +1,13 @@
+package pkg
+
+type WorkflowManager struct {
+	instance *Instance
+}
+
+func NewWorkflowManager(i *Instance) *WorkflowManager {
+	return &WorkflowManager{instance: i}
+}
+
+func (w *WorkflowManager) Launcher(path string) *WorkflowLauncher {
+	return &WorkflowLauncher{manager: w, path: path}
+}


### PR DESCRIPTION
fixes #5 

also adds new commands:

- `aem repo node copy --source-path x --target-path y`
- `aem repo node mv --source-path x --target-path y [--replace]`

also added 

- ` aem pkg deploy [--file|--url] [--force]` (to force reinstallation when pkg is already deployed; useful for experimenting)


aem.yml changes:


![image](https://user-images.githubusercontent.com/81212505/225343477-cffe6cc3-2e6b-4ed2-8f30-43019d347912.png)

<img width="628" alt="image" src="https://user-images.githubusercontent.com/81212505/225343668-34da16fd-b939-46e3-8669-809a26829536.png">

![image](https://user-images.githubusercontent.com/81212505/225343743-2a21f43b-ec10-4b8f-9522-593eb9fa66cf.png)

when activating `toggled_workflows` by uncommenting them in config then the package deployment time is reduced on my machine from 40 to 26s ;) 

as this is feature is nice for development environments may be too invasive for higher ones. that's why I want to have it disabled by default

@maciej-majchrzak-wttech , @tomasz-sobczyk-wttech  WDYT?


