### PR TITLE
Snapshot on remote instance bugfix

### DIFF
--- a/cmd/aem/root.go
+++ b/cmd/aem/root.go
@@ -58,7 +58,7 @@ func (c *CLI) rootFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().String("output-log-mode", cv.GetString("output.log.mode"), "Controls where outputs and logs should be written to when format is \"text\" ("+(strings.Join(cfg.OutputLogModes(), "|")+")"))
 	_ = cv.BindPFlag("output.log.mode", cmd.PersistentFlags().Lookup("output-log-mode"))
 
-	cmd.PersistentFlags().StringP("instance-url", "U", cv.GetString("instance.adhoc_url"), "Use only AEM instance at ad-hoc specified URL")
+	cmd.PersistentFlags().StringSliceP("instance-url", "U", cv.GetStringSlice("instance.adhoc_url"), "Use only AEM instance at ad-hoc specified URL")
 	_ = cv.BindPFlag("instance.adhoc_url", cmd.PersistentFlags().Lookup("instance-url"))
 
 	cmd.PersistentFlags().StringP("instance-id", "I", cv.GetString("instance.filter.id"), "Use only AEM instance configured with the exact ID")

--- a/pkg/instance.go
+++ b/pkg/instance.go
@@ -305,3 +305,10 @@ func (i Instance) MarshalText() string {
 	sb.WriteString(fmtx.TblProps(props))
 	return sb.String()
 }
+
+func (i Instance) LockDir() string {
+	if i.IsLocal() {
+		return i.local.LockDir()
+	}
+	return "" // TODO dir should reflect url or name? or configurable? for remote instances and features that are locked via local files like: pkg deploy skipping, SSL, ...
+}

--- a/pkg/instance.go
+++ b/pkg/instance.go
@@ -307,11 +307,10 @@ func (i Instance) MarshalText() string {
 }
 
 func (i Instance) LockDir() string {
-	return i.local.LockDir()
-	/*
-		if i.IsLocal() {
-			return i.local.LockDir()
-		}
-		return "" // TODO dir should reflect url or name? or configurable? for remote instances and features that are locked via local files like: pkg deploy skipping, SSL, ...
-	*/
+	if i.IsLocal() {
+		return i.local.LockDir()
+	}
+	log.Panic("%s > lock files for remote instances are not yet supported", i.ID())
+	return "" // TODO dir should reflect url or name? or configurable? for remote instances and features that are locked via local files like: pkg deploy skipping, SSL, ...
+
 }

--- a/pkg/instance.go
+++ b/pkg/instance.go
@@ -310,7 +310,7 @@ func (i Instance) LockDir() string {
 	if i.IsLocal() {
 		return i.local.LockDir()
 	}
-	log.Panic("%s > lock files for remote instances are not yet supported", i.ID())
+	log.Panicf("%s > lock files for remote instances are not yet supported", i.ID())
 	return "" // TODO dir should reflect url or name? or configurable? for remote instances and features that are locked via local files like: pkg deploy skipping, SSL, ...
 
 }

--- a/pkg/instance.go
+++ b/pkg/instance.go
@@ -307,8 +307,11 @@ func (i Instance) MarshalText() string {
 }
 
 func (i Instance) LockDir() string {
-	if i.IsLocal() {
-		return i.local.LockDir()
-	}
-	return "" // TODO dir should reflect url or name? or configurable? for remote instances and features that are locked via local files like: pkg deploy skipping, SSL, ...
+	return i.local.LockDir()
+	/*
+		if i.IsLocal() {
+			return i.local.LockDir()
+		}
+		return "" // TODO dir should reflect url or name? or configurable? for remote instances and features that are locked via local files like: pkg deploy skipping, SSL, ...
+	*/
 }

--- a/pkg/instance_manager.go
+++ b/pkg/instance_manager.go
@@ -20,7 +20,7 @@ type InstanceManager struct {
 	LocalOpts *LocalOpts
 	CheckOpts *CheckOpts
 
-	AdHocURL        string
+	AdHocURL        []string
 	FilterID        string
 	FilterAuthors   bool
 	FilterPublishes bool
@@ -33,7 +33,7 @@ func NewInstanceManager(aem *AEM) *InstanceManager {
 
 	cv := aem.config.Values()
 
-	result.AdHocURL = cv.GetString("instance.adhoc_url")
+	result.AdHocURL = cv.GetStringSlice("instance.adhoc_url")
 	result.FilterID = cv.GetString("instance.filter.id")
 	result.FilterAuthors = cv.GetBool("instance.filter.authors")
 	result.FilterPublishes = cv.GetBool("instance.filter.publishes")
@@ -83,12 +83,16 @@ func (im *InstanceManager) All() []Instance {
 }
 
 func (im *InstanceManager) newAdHocOrFromConfig() []Instance {
-	if im.AdHocURL != "" {
-		iURL, err := im.NewByURL(im.AdHocURL)
-		if err != nil {
-			log.Fatalf("cannot create instance from ad hoc URL '%s': %s", im.AdHocURL, err)
+	if len(im.AdHocURL) > 0 {
+		var result []Instance
+		for _, adHocURL := range im.AdHocURL {
+			iURL, err := im.NewByURL(adHocURL)
+			if err != nil {
+				log.Fatalf("cannot create instance from ad hoc URL '%s': %s", im.AdHocURL, err)
+			}
+			result = append(result, *iURL)
 		}
-		return []Instance{*iURL}
+		return result
 	}
 	cv := im.aem.config.Values()
 	configIDs := maps.Keys(cv.GetStringMap("instance.config"))

--- a/pkg/instance_manager.go
+++ b/pkg/instance_manager.go
@@ -85,8 +85,8 @@ func (im *InstanceManager) All() []Instance {
 func (im *InstanceManager) newAdHocOrFromConfig() []Instance {
 	if len(im.AdHocURL) > 0 {
 		var result []Instance
-		for _, adHocURL := range im.AdHocURL {
-			iURL, err := im.NewByURL(adHocURL)
+		for adHocIndex, adHocURL := range im.AdHocURL {
+			iURL, err := im.newByURL(adHocURL, adHocIndex+1)
 			if err != nil {
 				log.Fatalf("cannot create instance from ad hoc URL '%s': %s", im.AdHocURL, err)
 			}
@@ -219,6 +219,10 @@ func (im *InstanceManager) NewLocalPair() []Instance {
 }
 
 func (im *InstanceManager) NewByURL(url string) (*Instance, error) {
+	return im.newByURL(url, -1)
+}
+
+func (im *InstanceManager) newByURL(url string, classifierIndex int) (*Instance, error) {
 	urlConfig, err := nurl.Parse(url)
 	if err != nil {
 		return nil, fmt.Errorf("invalid instance URL '%s': %w", url, err)
@@ -226,7 +230,12 @@ func (im *InstanceManager) NewByURL(url string) (*Instance, error) {
 
 	env := locationByURL(urlConfig)
 	typeName := roleByURL(urlConfig)
-	classifier := classifierByURL(urlConfig)
+	var classifier string
+	if classifierIndex > 0 {
+		classifier = fmt.Sprintf("%d", classifierIndex)
+	} else {
+		classifierByURL(urlConfig)
+	}
 	user, password := credentialsByURL(urlConfig)
 
 	parts := []string{env, string(typeName)}

--- a/pkg/package_manager.go
+++ b/pkg/package_manager.go
@@ -209,7 +209,7 @@ func (pm *PackageManager) Install(remotePath string) error {
 }
 
 func (pm *PackageManager) DeployWithChanged(localPath string) (bool, error) {
-	if pm.IsSnapshot(localPath) {
+	if pm.instance.IsLocal() && pm.IsSnapshot(localPath) { // TODO remove local check; support remote as well
 		return pm.deploySnapshot(localPath)
 	}
 	return pm.deployRegular(localPath)

--- a/pkg/package_manager.go
+++ b/pkg/package_manager.go
@@ -209,7 +209,7 @@ func (pm *PackageManager) Install(remotePath string) error {
 }
 
 func (pm *PackageManager) DeployWithChanged(localPath string) (bool, error) {
-	if pm.IsSnapshot(localPath) {
+	if pm.instance.IsLocal() && pm.IsSnapshot(localPath) {
 		return pm.deploySnapshot(localPath)
 	}
 	return pm.deployRegular(localPath)

--- a/pkg/package_manager.go
+++ b/pkg/package_manager.go
@@ -209,7 +209,7 @@ func (pm *PackageManager) Install(remotePath string) error {
 }
 
 func (pm *PackageManager) DeployWithChanged(localPath string) (bool, error) {
-	if pm.instance.IsLocal() && pm.IsSnapshot(localPath) {
+	if pm.IsSnapshot(localPath) {
 		return pm.deploySnapshot(localPath)
 	}
 	return pm.deployRegular(localPath)
@@ -279,7 +279,7 @@ func (pm *PackageManager) Deploy(localPath string) error {
 
 func (pm *PackageManager) deployLock(file string, checksum string) osx.Lock[packageDeployLock] {
 	name := filepath.Base(file)
-	return osx.NewLock(fmt.Sprintf("%s/package/deploy/%s.yml", pm.instance.local.LockDir(), name), func() (packageDeployLock, error) {
+	return osx.NewLock(fmt.Sprintf("%s/package/deploy/%s.yml", pm.instance.LockDir(), name), func() (packageDeployLock, error) {
 		return packageDeployLock{Deployed: time.Now(), Checksum: checksum}, nil
 	})
 }

--- a/pkg/ssl.go
+++ b/pkg/ssl.go
@@ -170,7 +170,7 @@ func (s SSL) extractErrorMessage(body string) (errorMessage string, err error) {
 }
 
 func (s SSL) lock(keyStorePassword, trustStorePassword, certificateFile, privateKeyFile, httpsHostname, httpsPort string) osx.Lock[sslLock] {
-	return osx.NewLock(fmt.Sprintf("%s/ssl.yml", s.instance.local.LockDir()), func() (sslLock, error) {
+	return osx.NewLock(fmt.Sprintf("%s/ssl.yml", s.instance.LockDir()), func() (sslLock, error) {
 		certificateChecksum, err := filex.ChecksumFile(certificateFile)
 		if err != nil {
 			return sslLock{}, fmt.Errorf("%s > failed to calculate checksum for SSL certificate file: %w", s.instance.ID(), err)


### PR DESCRIPTION
as package `deployChanged` feature requires file locking it should be effectively disabled when using remote instances 