### PR TITLE
Await stable with instance URL and no explicit port number

### DIFF
--- a/pkg/http.go
+++ b/pkg/http.go
@@ -68,7 +68,15 @@ func (h *HTTP) BasicAuthCredentials() string {
 
 func (h *HTTP) Port() string {
 	urlConfig, _ := nurl.Parse(h.baseURL)
-	return urlConfig.Port()
+	port := urlConfig.Port()
+	if port == "" {
+		if urlConfig.Scheme == "https" {
+			port = "443"
+		} else {
+			port = "80"
+		}
+	}
+	return port
 }
 
 func (h *HTTP) Hostname() string {


### PR DESCRIPTION
this fixes "not reachable" check when instance URL has no explicit port number in the end e.g https://192.168.10.10 instead of https://192.168.10.10:443