### PR TITLE
Wrongly calculated timeout for instance await started checking

### DIFF
--- a/pkg/instance.go
+++ b/pkg/instance.go
@@ -265,7 +265,7 @@ func (i Instance) HealthChecks() []string {
 			i.manager.CheckOpts.Installer,
 		}
 		for _, check := range checks {
-			result := check.Check(i.manager.checkContext(), i)
+			result := check.Check(i.manager.CheckContext().Value(checkContextKey{}).(CheckContext), i)
 			if result.message != "" {
 				messages = append(messages, result.message)
 			} else if result.err != nil {

--- a/pkg/instance.go
+++ b/pkg/instance.go
@@ -265,7 +265,7 @@ func (i Instance) HealthChecks() []string {
 			i.manager.CheckOpts.Installer,
 		}
 		for _, check := range checks {
-			result := check.Check(i)
+			result := check.Check(i.manager.checkContext(), i)
 			if result.message != "" {
 				messages = append(messages, result.message)
 			} else if result.err != nil {

--- a/pkg/instance_manager_check.go
+++ b/pkg/instance_manager_check.go
@@ -57,16 +57,16 @@ type CheckContext struct {
 	Started time.Time
 }
 
-type CheckContextKey struct{}
+type checkContextKey struct{}
 
-func (im *InstanceManager) checkContext() context.Context {
-	return context.WithValue(context.Background(), CheckContextKey{}, CheckContext{
+func (im *InstanceManager) CheckContext() context.Context {
+	return context.WithValue(context.Background(), checkContextKey{}, CheckContext{
 		Started: time.Now(),
 	})
 }
 
 func (im *InstanceManager) CheckUntilDone(instances []Instance, opts *CheckOpts, checks []Checker) error {
-	return im.checkUntilDone(im.checkContext(), instances, opts, checks)
+	return im.checkUntilDone(im.CheckContext(), instances, opts, checks)
 }
 
 func (im *InstanceManager) checkUntilDone(ctx context.Context, instances []Instance, opts *CheckOpts, checks []Checker) error {
@@ -100,7 +100,7 @@ func (im *InstanceManager) checkUntilDone(ctx context.Context, instances []Insta
 }
 
 func (im *InstanceManager) CheckIfDone(instances []Instance, checks []Checker) (bool, error) {
-	return im.checkIfDone(im.checkContext(), instances, checks)
+	return im.checkIfDone(im.CheckContext(), instances, checks)
 }
 
 func (im *InstanceManager) checkIfDone(ctx context.Context, instances []Instance, checks []Checker) (bool, error) {
@@ -115,7 +115,7 @@ func (im *InstanceManager) checkIfDone(ctx context.Context, instances []Instance
 }
 
 func (im *InstanceManager) Check(instances []Instance, checks []Checker) ([][]CheckResult, error) {
-	return im.check(im.checkContext(), instances, checks)
+	return im.check(im.CheckContext(), instances, checks)
 }
 
 func (im *InstanceManager) check(ctx context.Context, instances []Instance, checks []Checker) ([][]CheckResult, error) {
@@ -123,13 +123,13 @@ func (im *InstanceManager) check(ctx context.Context, instances []Instance, chec
 }
 
 func (im *InstanceManager) CheckOne(i Instance, checks []Checker) ([]CheckResult, error) {
-	return im.checkOne(im.checkContext(), i, checks)
+	return im.checkOne(im.CheckContext(), i, checks)
 }
 
 func (im *InstanceManager) checkOne(ctx context.Context, i Instance, checks []Checker) ([]CheckResult, error) {
 	var results []CheckResult
 	for _, check := range checks {
-		result := check.Check(ctx, i)
+		result := check.Check(ctx.Value(checkContextKey{}).(CheckContext), i)
 		results = append(results, result)
 		if result.abort {
 			log.Fatal(InstanceMsg(i, result.message))

--- a/pkg/instance_manager_check.go
+++ b/pkg/instance_manager_check.go
@@ -1,6 +1,7 @@
 package pkg
 
 import (
+	"context"
 	"fmt"
 	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
@@ -52,7 +53,23 @@ func NewCheckOpts(manager *InstanceManager) *CheckOpts {
 	return result
 }
 
+type CheckContext struct {
+	Started time.Time
+}
+
+type CheckContextKey struct{}
+
+func (im *InstanceManager) checkContext() context.Context {
+	return context.WithValue(context.Background(), CheckContextKey{}, CheckContext{
+		Started: time.Now(),
+	})
+}
+
 func (im *InstanceManager) CheckUntilDone(instances []Instance, opts *CheckOpts, checks []Checker) error {
+	return im.checkUntilDone(im.checkContext(), instances, opts, checks)
+}
+
+func (im *InstanceManager) checkUntilDone(ctx context.Context, instances []Instance, opts *CheckOpts, checks []Checker) error {
 	if len(instances) == 0 {
 		log.Debug("no instances to check")
 		return nil
@@ -60,7 +77,7 @@ func (im *InstanceManager) CheckUntilDone(instances []Instance, opts *CheckOpts,
 	time.Sleep(opts.Warmup)
 	doneTimes := 0
 	for {
-		done, err := im.CheckIfDone(instances, checks)
+		done, err := im.checkIfDone(ctx, instances, checks)
 		if err != nil {
 			return err
 		}
@@ -83,7 +100,11 @@ func (im *InstanceManager) CheckUntilDone(instances []Instance, opts *CheckOpts,
 }
 
 func (im *InstanceManager) CheckIfDone(instances []Instance, checks []Checker) (bool, error) {
-	instanceResults, err := im.Check(instances, checks)
+	return im.checkIfDone(im.checkContext(), instances, checks)
+}
+
+func (im *InstanceManager) checkIfDone(ctx context.Context, instances []Instance, checks []Checker) (bool, error) {
+	instanceResults, err := im.check(ctx, instances, checks)
 	if err != nil {
 		return false, nil
 	}
@@ -94,13 +115,21 @@ func (im *InstanceManager) CheckIfDone(instances []Instance, checks []Checker) (
 }
 
 func (im *InstanceManager) Check(instances []Instance, checks []Checker) ([][]CheckResult, error) {
-	return InstanceProcess(im.aem, instances, func(i Instance) ([]CheckResult, error) { return im.CheckOne(i, checks) })
+	return im.check(im.checkContext(), instances, checks)
+}
+
+func (im *InstanceManager) check(ctx context.Context, instances []Instance, checks []Checker) ([][]CheckResult, error) {
+	return InstanceProcess(im.aem, instances, func(i Instance) ([]CheckResult, error) { return im.checkOne(ctx, i, checks) })
 }
 
 func (im *InstanceManager) CheckOne(i Instance, checks []Checker) ([]CheckResult, error) {
+	return im.checkOne(im.checkContext(), i, checks)
+}
+
+func (im *InstanceManager) checkOne(ctx context.Context, i Instance, checks []Checker) ([]CheckResult, error) {
 	var results []CheckResult
 	for _, check := range checks {
-		result := check.Check(i)
+		result := check.Check(ctx, i)
 		results = append(results, result)
 		if result.abort {
 			log.Fatal(InstanceMsg(i, result.message))


### PR DESCRIPTION
this is a fix for the error message `timeout after 30m 0s, expected state 'started' not reached`

AwaitStartedCheck was assigning the Started field during AEM Compose API initialization which was too early.
One of the previous refactorings in that area made checks configurable via YML config etc. but changed how these checks are instantiated, not by function but early when API is created.

The fix here introduces context to be able to pass variables scoped to the actual checking run time.