### PR TITLE
Package upload - memory efficient, const usage

### DIFF
--- a/cmd/aem/package.go
+++ b/cmd/aem/package.go
@@ -96,8 +96,15 @@ func (c *CLI) pkgUploadCmd() *cobra.Command {
 				c.Error(err)
 				return
 			}
+			force, _ := cmd.Flags().GetBool("force")
 			uploaded, err := pkg.InstanceProcess(c.aem, instances, func(instance pkg.Instance) (map[string]any, error) {
-				changed, err := instance.PackageManager().UploadWithChanged(path)
+				changed := false
+				if force {
+					_, err = instance.PackageManager().Upload(path)
+					changed = true
+				} else {
+					changed, err = instance.PackageManager().UploadWithChanged(path)
+				}
 				if err != nil {
 					return nil, err
 				}
@@ -128,6 +135,7 @@ func (c *CLI) pkgUploadCmd() *cobra.Command {
 		},
 	}
 	pkgDefineFileAndUrlFlags(cmd)
+	cmd.Flags().BoolP("force", "f", false, "Upload even when already uploaded")
 	return cmd
 }
 

--- a/pkg/cfg/defaults.go
+++ b/pkg/cfg/defaults.go
@@ -83,6 +83,8 @@ func (c *Config) setDefaults() {
 
 	v.SetDefault("instance.status.timeout", time.Millisecond*500)
 
+	v.SetDefault("instance.package.upload_optimized", true)
+
 	v.SetDefault("instance.package.install_recursive", true)
 
 	v.SetDefault("instance.package.install_html.enabled", false)

--- a/pkg/package_manager.go
+++ b/pkg/package_manager.go
@@ -354,6 +354,7 @@ func (pm *PackageManager) Upload(localPath string) (string, error) {
 }
 
 // https://medium.com/@owlwalks/sending-big-file-with-minimal-memory-in-golang-8f3fc280d2c
+// https://github.com/go-resty/resty/issues/309#issuecomment-1750659170
 func (pm *PackageManager) uploadOptimized(localPath string) (string, error) {
 	log.Infof("%s > uploading package '%s'", pm.instance.ID(), localPath)
 	r, w := io.Pipe()

--- a/pkg/package_manager.go
+++ b/pkg/package_manager.go
@@ -15,7 +15,10 @@ import (
 	"github.com/wttech/aemc/pkg/common/timex"
 	"github.com/wttech/aemc/pkg/common/tplx"
 	"github.com/wttech/aemc/pkg/pkg"
+	"io"
 	"io/fs"
+	"mime/multipart"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -26,6 +29,7 @@ type PackageManager struct {
 	instance *Instance
 
 	SnapshotDeploySkipping bool
+	UploadOptimized        bool
 	InstallRecursive       bool
 	InstallHTMLEnabled     bool
 	InstallHTMLConsole     bool
@@ -41,6 +45,7 @@ func NewPackageManager(res *Instance) *PackageManager {
 		instance: res,
 
 		SnapshotDeploySkipping: cv.GetBool("instance.package.snapshot_deploy_skipping"),
+		UploadOptimized:        cv.GetBool("instance.package.upload_optimized"),
 		InstallHTMLEnabled:     cv.GetBool("instance.package.install_html.enabled"),
 		InstallHTMLConsole:     cv.GetBool("instance.package.install_html.console"),
 		InstallHTMLStrict:      cv.GetBool("instance.package.install_html.strict"),
@@ -342,6 +347,58 @@ func (pm *PackageManager) UploadWithChanged(localPath string) (bool, error) {
 }
 
 func (pm *PackageManager) Upload(localPath string) (string, error) {
+	if pm.UploadOptimized {
+		return pm.uploadOptimized(localPath)
+	}
+	return pm.uploadBuffered(localPath)
+}
+
+// https://medium.com/@owlwalks/sending-big-file-with-minimal-memory-in-golang-8f3fc280d2c
+func (pm *PackageManager) uploadOptimized(localPath string) (string, error) {
+	log.Infof("%s > uploading package '%s'", pm.instance.ID(), localPath)
+	r, w := io.Pipe()
+	m := multipart.NewWriter(w)
+	go func() {
+		defer func(w *io.PipeWriter) { _ = w.Close() }(w)
+		defer func(m *multipart.Writer) { _ = m.Close() }(m)
+		part, err := m.CreateFormFile("package", filepath.Base(localPath))
+		if err != nil {
+			return
+		}
+		file, err := os.Open(localPath)
+		if err != nil {
+			return
+		}
+		defer func(file *os.File) { _ = file.Close() }(file)
+		if _, err = io.Copy(part, file); err != nil {
+			return
+		}
+	}()
+	request, err := http.NewRequest("POST", pm.instance.HTTP().BaseURL()+ServiceJsonPath+"/?cmd=upload&force=true", r)
+	if err != nil {
+		return "", err
+	}
+	request.Header.Set("Content-Type", m.FormDataContentType())
+	request.SetBasicAuth(pm.instance.user, pm.instance.password)
+	client := &http.Client{}
+	response, err := client.Do(request)
+	if err != nil {
+		return "", fmt.Errorf("%s > cannot upload package '%s': %w", pm.instance.ID(), localPath, err)
+	} else if response.StatusCode > 399 {
+		return "", fmt.Errorf("%s > cannot upload package '%s': %s", pm.instance.ID(), localPath, response.Status)
+	}
+	var status pkg.CommandResult
+	if err = fmtx.UnmarshalJSON(response.Body, &status); err != nil {
+		return "", fmt.Errorf("%s > cannot upload package '%s'; cannot parse response: %w", pm.instance.ID(), localPath, err)
+	}
+	if !status.Success {
+		return "", fmt.Errorf("%s > cannot upload package '%s'; unexpected status: %s", pm.instance.ID(), localPath, status.Message)
+	}
+	log.Infof("%s > uploaded package '%s'", pm.instance.ID(), localPath)
+	return status.Path, nil
+}
+
+func (pm *PackageManager) uploadBuffered(localPath string) (string, error) {
 	log.Infof("%s > uploading package '%s'", pm.instance.ID(), localPath)
 	response, err := pm.instance.http.Request().
 		SetFile("package", localPath).


### PR DESCRIPTION
fix for uploading big packages inspired by: https://medium.com/@owlwalks/sending-big-file-with-minimal-memory-in-golang-8f3fc280d2c to avoid exceeding available memory on CI/CD systems e.g when uploading 17 GB package and having only 16 GB of RAM available

benchmarks done:

```
assuming package file "other-method.zip" of size 211.2 MB
=====

[1] legacy package manager upload method

AEM_INSTANCE_CHECK_SKIP=true AEM_OUTPUT_VALUE=NONE AEM_INSTANCE_PACKAGE_UPLOAD_OPTIMIZED=true /usr/bin/time -l sh aemw pkg upload --file other-method.zip -f -A
              
        2.91 real         0.07 user         0.24 sys
            15843328  maximum resident set size

=> 15 MB


[2] optimized package manager upload method

AEM_INSTANCE_CHECK_SKIP=true AEM_OUTPUT_VALUE=NONE AEM_INSTANCE_PACKAGE_UPLOAD_OPTIMIZED=true /usr/bin/time -l sh aemw pkg upload --file other-method.zip -f -A


699793408  maximum resident set size => 699 MB

 3.27 real         0.22 user         0.25 sys
 699793408  maximum resident set size 

=> 699 MB


=====

1000 mb ~ 1 GB package


[1] legacy

       13.31 real         0.38 user         0.61 sys
          2747252736  maximum resident set size

=> 2747 MB


[2] optimized

13.13 real         0.29 user         0.79 sys
            15990784  maximum resident set size

=> 15.99 MB
```

results:

- for smaller packages legacy method may be faster but only a little (negligible difference)
- for bigger packages new method is faster and uses constant memory (16 MB)

Based on that result decided to use the optimized method by default;
if there are some stability problems the old method will still be available by setting 

```
AEM_INSTANCE_PACKAGE_UPLOAD_OPTIMIZED=false
```