### PR TITLE
Repo download command

### DIFF
--- a/cmd/aem/package.go
+++ b/cmd/aem/package.go
@@ -443,7 +443,11 @@ func (c *CLI) pkgBuildCmd() *cobra.Command {
 			}
 		},
 	}
-	pkgDefineBuildFlags(cmd)
+	cmd.Flags().String("pid", "", "ID (group:name:version)'")
+	cmd.Flags().String("path", "", "Remote repository path")
+	cmd.MarkFlagsMutuallyExclusive("pid", "path")
+	cmd.Flags().BoolP("force", "f", false, "Build even when already built")
+	cmd.MarkFlagsOneRequired("pid", "path")
 	return cmd
 }
 
@@ -452,41 +456,6 @@ func pkgDefineFlags(cmd *cobra.Command) {
 	cmd.Flags().String("file", "", "Local file path")
 	cmd.Flags().String("path", "", "Remote repository path")
 	cmd.MarkFlagsMutuallyExclusive("pid", "file", "path")
-}
-
-func pkgDefineDownloadFlags(cmd *cobra.Command) {
-	cmd.Flags().String("pid", "", "ID (group:name:version)'")
-	cmd.Flags().String("path", "", "Remote repository path")
-	cmd.Flags().StringP("target-file", "t", "", "Target file path")
-	cmd.Flags().BoolP("force", "f", false, "Download even when already downloaded")
-	_ = cmd.MarkFlagRequired("file")
-	cmd.MarkFlagsOneRequired("pid", "path")
-	cmd.MarkFlagsMutuallyExclusive("pid", "path")
-}
-
-func pkgDefineUpdateFlags(cmd *cobra.Command) {
-	cmd.Flags().String("pid", "", "ID (group:name:version)'")
-	cmd.Flags().String("path", "", "Remote repository path")
-	cmd.Flags().StringSliceP("filter-roots", "r", []string{}, "Vault filter root paths")
-	cmd.MarkFlagsOneRequired("pid", "path")
-	cmd.MarkFlagsMutuallyExclusive("pid", "path")
-}
-
-func pkgDefineCreateFlags(cmd *cobra.Command) {
-	cmd.Flags().String("pid", "", "ID (group:name:version)'")
-	cmd.Flags().StringSliceP("filter-roots", "r", []string{}, "Vault filter root paths")
-	cmd.Flags().StringP("filter-file", "F", "", "Vault filter file path")
-	cmd.MarkFlagsMutuallyExclusive("filter-roots", "filter-file")
-	cmd.Flags().BoolP("force", "f", false, "Create even when already created")
-	_ = cmd.MarkFlagRequired("pid")
-}
-
-func pkgDefineBuildFlags(cmd *cobra.Command) {
-	cmd.Flags().String("pid", "", "ID (group:name:version)'")
-	cmd.Flags().String("path", "", "Remote repository path")
-	cmd.MarkFlagsMutuallyExclusive("pid", "path")
-	cmd.Flags().BoolP("force", "f", false, "Build even when already built")
-	cmd.MarkFlagsOneRequired("pid", "path")
 }
 
 func pkgByFlags(cmd *cobra.Command, instance pkg.Instance) (*pkg.Package, error) {
@@ -604,7 +573,12 @@ func (c *CLI) pkgCreateCmd() *cobra.Command {
 			}
 		},
 	}
-	pkgDefineCreateFlags(cmd)
+	cmd.Flags().String("pid", "", "ID (group:name:version)'")
+	cmd.Flags().StringSliceP("filter-roots", "r", []string{}, "Vault filter root paths")
+	cmd.Flags().StringP("filter-file", "F", "", "Vault filter file path")
+	cmd.MarkFlagsMutuallyExclusive("filter-roots", "filter-file")
+	cmd.Flags().BoolP("force", "f", false, "Create even when already created")
+	_ = cmd.MarkFlagRequired("pid")
 	return cmd
 }
 
@@ -633,14 +607,19 @@ func (c *CLI) pkgUpdateCmd() *cobra.Command {
 			c.Changed("package filters updated") // TODO idempotency?
 		},
 	}
-	pkgDefineUpdateFlags(cmd)
+	cmd.Flags().String("pid", "", "ID (group:name:version)'")
+	cmd.Flags().String("path", "", "Remote repository path")
+	cmd.Flags().StringSliceP("filter-roots", "r", []string{}, "Vault filter root paths")
+	cmd.MarkFlagsOneRequired("pid", "path")
+	cmd.MarkFlagsMutuallyExclusive("pid", "path")
 	return cmd
 }
 
 func (c *CLI) pkgDownloadCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "download",
-		Short: "Download package(s)",
+		Use:     "download",
+		Aliases: []string{"dl"},
+		Short:   "Download package",
 		Run: func(cmd *cobra.Command, args []string) {
 			instance, err := c.aem.InstanceManager().One()
 			if err != nil {
@@ -675,7 +654,13 @@ func (c *CLI) pkgDownloadCmd() *cobra.Command {
 			}
 		},
 	}
-	pkgDefineDownloadFlags(cmd)
+	cmd.Flags().String("pid", "", "ID (group:name:version)'")
+	cmd.Flags().String("path", "", "Remote repository path")
+	cmd.Flags().StringP("target-file", "t", "", "Target file path")
+	cmd.Flags().BoolP("force", "f", false, "Download even when already downloaded")
+	_ = cmd.MarkFlagRequired("file")
+	cmd.MarkFlagsOneRequired("pid", "path")
+	cmd.MarkFlagsMutuallyExclusive("pid", "path")
 	return cmd
 }
 

--- a/cmd/aem/repo.go
+++ b/cmd/aem/repo.go
@@ -260,7 +260,7 @@ func (c *CLI) repoNodeMoveCmd() *cobra.Command {
 func (c *CLI) repoNodeDownloadCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "download",
-		Short:   "Download node pointing to file",
+		Short:   "Download node to file",
 		Aliases: []string{"dl"},
 		Run: func(cmd *cobra.Command, args []string) {
 			instance, err := c.aem.InstanceManager().One()
@@ -295,6 +295,7 @@ func (c *CLI) repoNodeDownloadCmd() *cobra.Command {
 	}
 	repoNodeDefineFlags(cmd)
 	cmd.Flags().StringP("target-file", "t", "", "Target file path")
+	_ = cmd.MarkFlagRequired("target-file")
 	cmd.Flags().BoolP("force", "f", false, "Download even when already downloaded")
 	return cmd
 }

--- a/cmd/aem/repo.go
+++ b/cmd/aem/repo.go
@@ -29,6 +29,7 @@ func (c *CLI) repoNodeCmd() *cobra.Command {
 	cmd.AddCommand(c.repoNodeCopyCmd())
 	cmd.AddCommand(c.repoNodeMoveCmd())
 	cmd.AddCommand(c.repoNodeChildrenCmd())
+	cmd.AddCommand(c.repoNodeDownloadCmd())
 
 	return cmd
 }
@@ -253,6 +254,48 @@ func (c *CLI) repoNodeMoveCmd() *cobra.Command {
 	cmd.Flags().StringP("target-path", "t", "", "Target path")
 	cmd.MarkFlagRequired("target-path")
 	cmd.Flags().BoolP("replace", "r", false, "Replace target node if it already exists")
+	return cmd
+}
+
+func (c *CLI) repoNodeDownloadCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "download",
+		Short:   "Download node pointing to file",
+		Aliases: []string{"dl"},
+		Run: func(cmd *cobra.Command, args []string) {
+			instance, err := c.aem.InstanceManager().One()
+			if err != nil {
+				c.Error(err)
+				return
+			}
+			node := repoNodeByFlags(cmd, *instance)
+			targetFile, _ := cmd.Flags().GetString("target-file")
+			force, _ := cmd.Flags().GetBool("force")
+			changed := false
+			if force {
+				err = node.Download(targetFile)
+				changed = true
+			} else {
+				changed, err = node.DownloadWithChanged(targetFile)
+			}
+			if err != nil {
+				c.Error(err)
+				return
+			}
+			if changed {
+				c.Changed("node downloaded")
+			} else {
+				c.Ok("node not downloaded (up-to-date)")
+			}
+			c.SetOutput("node", node)
+			c.SetOutput("instance", instance)
+			c.SetOutput("file", targetFile)
+			c.Ok("node downloaded")
+		},
+	}
+	repoNodeDefineFlags(cmd)
+	cmd.Flags().StringP("target-file", "t", "", "Target file path")
+	cmd.Flags().BoolP("force", "f", false, "Download even when already downloaded")
 	return cmd
 }
 

--- a/pkg/project/common/taskw
+++ b/pkg/project/common/taskw
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 
-VERSION=${TASK_VERSION:-"3.28.0"}
+VERSION=${TASK_VERSION:-"3.31.0"}
 
 # Define API
 # ==========

--- a/pkg/repo.go
+++ b/pkg/repo.go
@@ -7,6 +7,7 @@ import (
 	"github.com/samber/lo"
 	log "github.com/sirupsen/logrus"
 	"github.com/wttech/aemc/pkg/common/fmtx"
+	"github.com/wttech/aemc/pkg/common/httpx"
 	"github.com/wttech/aemc/pkg/common/mapsx"
 	"github.com/wttech/aemc/pkg/repo"
 	"net/http"
@@ -175,6 +176,20 @@ func NewRepoNodeList(nodes []RepoNode) NodeList {
 type NodeList struct {
 	Total int        `json:"total" yaml:"total"`
 	Nodes []RepoNode `json:"nodes" yaml:"nodes"`
+}
+
+func (r Repo) Download(remotePath string, localFile string) error {
+	log.Infof("%s > downloading node '%s'", r.instance.ID(), remotePath)
+	if err := httpx.DownloadWithOpts(httpx.DownloadOpts{
+		Client:   r.instance.http.Client(),
+		URL:      remotePath,
+		File:     localFile,
+		Override: true,
+	}); err != nil {
+		return fmt.Errorf("%s > cannot download node '%s': %w", r.instance.ID(), remotePath, err)
+	}
+	log.Infof("%s > downloaded node '%s'", r.instance.ID(), remotePath)
+	return nil
 }
 
 func (nl NodeList) MarshalText() string {

--- a/pkg/repo_node.go
+++ b/pkg/repo_node.go
@@ -7,6 +7,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/wttech/aemc/pkg/common/fmtx"
 	"github.com/wttech/aemc/pkg/common/langx"
+	"github.com/wttech/aemc/pkg/common/pathx"
 	"github.com/wttech/aemc/pkg/common/stringsx"
 	"golang.org/x/exp/maps"
 	"strings"
@@ -290,6 +291,31 @@ func (n RepoNode) MoveWithChanged(targetPath string, replace bool) (bool, error)
 		}
 	}
 	return true, n.repo.Move(n.path, targetPath, replace)
+}
+
+func (n RepoNode) Download(localFile string) error {
+	state, err := n.State()
+	if err != nil {
+		return err
+	}
+	if !state.Exists {
+		return fmt.Errorf("%s > node '%s' cannot be downloaded as it does not exist", n.repo.instance.ID(), n.path)
+	}
+	return n.repo.Download(state.Path, localFile)
+}
+
+func (n RepoNode) DownloadWithChanged(localFile string) (bool, error) {
+	state, err := n.State()
+	if err != nil {
+		return false, err
+	}
+	if !state.Exists {
+		return false, fmt.Errorf("%s > node '%s' cannot be downloaded as it does not exist", n.repo.instance.ID(), n.path)
+	}
+	if !pathx.Exists(localFile) {
+		return true, n.repo.Download(state.Path, localFile)
+	}
+	return false, nil
 }
 
 func (n RepoNode) String() string {


### PR DESCRIPTION
this method is almost the same as pkg download; the difference here is that it does not call list.jsp/service.jsp service which sometimes may be unavailable (is needed to determine path basing on PID); here we are just going straightforward