### PR TITLE
OSGi components checking

### DIFF
--- a/examples/docker/src/aem/default/etc/aem.yml
+++ b/examples/docker/src/aem/default/etc/aem.yml
@@ -89,6 +89,10 @@ instance:
         - "org.osgi.service.component.runtime.ServiceComponentRuntime"
         - "java.util.ResourceBundle"
       received_max_age: 5s
+    # OSGi components state tracking
+    component_stable:
+      pids_failed_activation: ["*"]
+      pids_unsatisfied_reference: []
     # Sling Installer tracking
     installer:
       # JMX state checking

--- a/examples/docker/src/aem/default/etc/aem.yml
+++ b/examples/docker/src/aem/default/etc/aem.yml
@@ -91,6 +91,7 @@ instance:
       received_max_age: 5s
     # OSGi components state tracking
     component_stable:
+      pids_ignored: []
       pids_failed_activation: ["*"]
       pids_unsatisfied_reference: []
     # Sling Installer tracking

--- a/pkg/cfg/defaults.go
+++ b/pkg/cfg/defaults.go
@@ -59,6 +59,9 @@ func (c *Config) setDefaults() {
 	v.SetDefault("instance.check.event_stable.topics_unstable", []string{"org/osgi/framework/ServiceEvent/*", "org/osgi/framework/FrameworkEvent/*", "org/osgi/framework/BundleEvent/*"})
 	v.SetDefault("instance.check.event_stable.details_ignored", []string{"*.*MBean", "org.osgi.service.component.runtime.ServiceComponentRuntime", "java.util.ResourceBundle"})
 
+	v.SetDefault("instance.check.component_stable.pids_failed_activation", []string{"*"})
+	v.SetDefault("instance.check.component_stable.pids_unsatisfied_reference", []string{})
+
 	v.SetDefault("instance.check.installer.state", true)
 	v.SetDefault("instance.check.installer.pause", true)
 

--- a/pkg/cfg/defaults.go
+++ b/pkg/cfg/defaults.go
@@ -53,21 +53,29 @@ func (c *Config) setDefaults() {
 	v.SetDefault("instance.check.await_started.timeout", time.Minute*30)
 	v.SetDefault("instance.check.await_stopped.timeout", time.Minute*10)
 
+	v.SetDefault("instance.check.reachable.skip", false)
 	v.SetDefault("instance.check.reachable.timeout", time.Second*3)
 
+	v.SetDefault("instance.check.bundle_stable.skip", false)
+	v.SetDefault("instance.check.bundle_stable.symbolic_names_ignored", []string{})
+
+	v.SetDefault("instance.check.event_stable.skip", false)
 	v.SetDefault("instance.check.event_stable.received_max_age", time.Second*5)
 	v.SetDefault("instance.check.event_stable.topics_unstable", []string{"org/osgi/framework/ServiceEvent/*", "org/osgi/framework/FrameworkEvent/*", "org/osgi/framework/BundleEvent/*"})
 	v.SetDefault("instance.check.event_stable.details_ignored", []string{"*.*MBean", "org.osgi.service.component.runtime.ServiceComponentRuntime", "java.util.ResourceBundle"})
 
+	v.SetDefault("instance.check.component_stable.skip", false)
 	v.SetDefault("instance.check.component_stable.pids_ignored", []string{})
 	v.SetDefault("instance.check.component_stable.pids_failed_activation", []string{"*"})
 	v.SetDefault("instance.check.component_stable.pids_unsatisfied_reference", []string{})
 
+	v.SetDefault("instance.check.installer.skip", false)
 	v.SetDefault("instance.check.installer.state", true)
 	v.SetDefault("instance.check.installer.pause", true)
 
 	v.SetDefault("instance.check.path_ready.timeout", time.Second*10)
 
+	v.SetDefault("instance.check.login_page.skip", false)
 	v.SetDefault("instance.check.login_page.path", "/libs/granite/core/content/login.html")
 	v.SetDefault("instance.check.login_page.status_code", 200)
 	v.SetDefault("instance.check.login_page.contained_text", "QUICKSTART_HOMEPAGE")

--- a/pkg/cfg/defaults.go
+++ b/pkg/cfg/defaults.go
@@ -59,6 +59,7 @@ func (c *Config) setDefaults() {
 	v.SetDefault("instance.check.event_stable.topics_unstable", []string{"org/osgi/framework/ServiceEvent/*", "org/osgi/framework/FrameworkEvent/*", "org/osgi/framework/BundleEvent/*"})
 	v.SetDefault("instance.check.event_stable.details_ignored", []string{"*.*MBean", "org.osgi.service.component.runtime.ServiceComponentRuntime", "java.util.ResourceBundle"})
 
+	v.SetDefault("instance.check.component_stable.pids_ignored", []string{})
 	v.SetDefault("instance.check.component_stable.pids_failed_activation", []string{"*"})
 	v.SetDefault("instance.check.component_stable.pids_unsatisfied_reference", []string{})
 

--- a/pkg/check.go
+++ b/pkg/check.go
@@ -37,6 +37,7 @@ type Checker interface {
 }
 
 type CheckSpec struct {
+	Skip      bool // occasionally skip checking e.g. due to performance reasons
 	Mandatory bool // indicates if next checks should be skipped if that particular one fails
 }
 
@@ -65,7 +66,7 @@ func (c AwaitChecker) Check(ctx CheckContext, _ Instance) CheckResult {
 }
 
 func (c AwaitChecker) Spec() CheckSpec {
-	return CheckSpec{Mandatory: true}
+	return CheckSpec{Skip: false, Mandatory: true}
 }
 
 type AwaitChecker struct {
@@ -77,15 +78,17 @@ func NewBundleStableChecker(opts *CheckOpts) BundleStableChecker {
 	cv := opts.manager.aem.config.Values()
 
 	return BundleStableChecker{
+		Skip:                 cv.GetBool("instance.check.bundle_stable.skip"),
 		SymbolicNamesIgnored: cv.GetStringSlice("instance.check.bundle_stable.symbolic_names_ignored"),
 	}
 }
 
 func (c BundleStableChecker) Spec() CheckSpec {
-	return CheckSpec{Mandatory: true}
+	return CheckSpec{Skip: c.Skip, Mandatory: true}
 }
 
 type BundleStableChecker struct {
+	Skip                 bool
 	SymbolicNamesIgnored []string
 }
 
@@ -121,6 +124,7 @@ func (c BundleStableChecker) Check(_ CheckContext, instance Instance) CheckResul
 }
 
 type EventStableChecker struct {
+	Skip           bool
 	ReceivedMaxAge time.Duration
 	TopicsUnstable []string
 	DetailsIgnored []string
@@ -130,6 +134,7 @@ func NewEventStableChecker(opts *CheckOpts) EventStableChecker {
 	cv := opts.manager.aem.config.Values()
 
 	return EventStableChecker{
+		Skip:           cv.GetBool("instance.check.event_stable.skip"),
 		ReceivedMaxAge: cv.GetDuration("instance.check.event_stable.received_max_age"),
 		TopicsUnstable: cv.GetStringSlice("instance.check.event_stable.topics_unstable"),
 		DetailsIgnored: cv.GetStringSlice("instance.check.event_stable.details_ignored"),
@@ -137,7 +142,7 @@ func NewEventStableChecker(opts *CheckOpts) EventStableChecker {
 }
 
 func (c EventStableChecker) Spec() CheckSpec {
-	return CheckSpec{Mandatory: true}
+	return CheckSpec{Skip: c.Skip, Mandatory: true}
 }
 
 func (c EventStableChecker) Check(_ CheckContext, instance Instance) CheckResult {
@@ -181,6 +186,7 @@ func (c EventStableChecker) Check(_ CheckContext, instance Instance) CheckResult
 }
 
 type ComponentStableChecker struct {
+	Skip                     bool
 	PIDsIgnored              []string
 	PIDsFailedActivation     []string
 	PIDsUnsatisfiedReference []string
@@ -190,6 +196,7 @@ func NewComponentStableChecker(opts *CheckOpts) ComponentStableChecker {
 	cv := opts.manager.aem.config.Values()
 
 	return ComponentStableChecker{
+		Skip:                     cv.GetBool("instance.check.component_stable.skip"),
 		PIDsIgnored:              cv.GetStringSlice("instance.check.component_stable.pids_ignored"),
 		PIDsFailedActivation:     cv.GetStringSlice("instance.check.component_stable.pids_failed_activation"),
 		PIDsUnsatisfiedReference: cv.GetStringSlice("instance.check.component_stable.pids_unsatisfied_reference"),
@@ -197,7 +204,7 @@ func NewComponentStableChecker(opts *CheckOpts) ComponentStableChecker {
 }
 
 func (c ComponentStableChecker) Spec() CheckSpec {
-	return CheckSpec{Mandatory: true}
+	return CheckSpec{Skip: c.Skip, Mandatory: true}
 }
 
 func (c ComponentStableChecker) Check(_ CheckContext, instance Instance) CheckResult {
@@ -240,22 +247,24 @@ func (c ComponentStableChecker) Check(_ CheckContext, instance Instance) CheckRe
 	}
 }
 
+type InstallerChecker struct {
+	Skip  bool
+	State bool
+	Pause bool
+}
+
 func NewInstallerChecker(opts *CheckOpts) InstallerChecker {
 	cv := opts.manager.aem.config.Values()
 
 	return InstallerChecker{
+		Skip:  cv.GetBool("instance.check.installer.skip"),
 		State: cv.GetBool("instance.check.installer.state"),
 		Pause: cv.GetBool("instance.check.installer.pause"),
 	}
 }
 
-type InstallerChecker struct {
-	State bool
-	Pause bool
-}
-
 func (c InstallerChecker) Spec() CheckSpec {
-	return CheckSpec{Mandatory: false}
+	return CheckSpec{Skip: c.Skip, Mandatory: false}
 }
 
 func (c InstallerChecker) Check(_ CheckContext, instance Instance) CheckResult {
@@ -307,7 +316,7 @@ func NewStatusStoppedChecker() StatusStoppedChecker {
 type StatusStoppedChecker struct{}
 
 func (c StatusStoppedChecker) Spec() CheckSpec {
-	return CheckSpec{Mandatory: true}
+	return CheckSpec{Skip: false, Mandatory: true}
 }
 
 func (c StatusStoppedChecker) Check(_ CheckContext, instance Instance) CheckResult {
@@ -345,6 +354,7 @@ func NewReachableChecker(opts *CheckOpts, reachable bool) ReachableHTTPChecker {
 	cv := opts.manager.aem.config.Values()
 
 	return ReachableHTTPChecker{
+		Skip:      cv.GetBool("instance.check.reachable.skip"),
 		Mandatory: reachable,
 		Reachable: reachable,
 		Timeout:   cv.GetDuration("instance.check.reachable.timeout"),
@@ -352,13 +362,14 @@ func NewReachableChecker(opts *CheckOpts, reachable bool) ReachableHTTPChecker {
 }
 
 type ReachableHTTPChecker struct {
+	Skip      bool
 	Mandatory bool
 	Reachable bool
 	Timeout   time.Duration
 }
 
 func (c ReachableHTTPChecker) Spec() CheckSpec {
-	return CheckSpec{Mandatory: c.Mandatory}
+	return CheckSpec{Skip: c.Skip, Mandatory: c.Mandatory}
 }
 
 func (c ReachableHTTPChecker) Check(_ CheckContext, instance Instance) CheckResult {
@@ -381,17 +392,19 @@ func (c ReachableHTTPChecker) Check(_ CheckContext, instance Instance) CheckResu
 
 func NewLoginPageChecker(opts *CheckOpts) PathHTTPChecker {
 	cv := opts.manager.aem.config.Values()
-	return NewPathReadyChecker(opts, "login page",
+	return NewPathReadyChecker(opts, cv.GetBool("instance.check.login_page.skip"),
+		"login page",
 		cv.GetString("instance.check.login_page.path"),
 		cv.GetInt("instance.check.login_page.status_code"),
 		cv.GetString("instance.check.login_page.contained_text"),
 	)
 }
 
-func NewPathReadyChecker(opts *CheckOpts, name string, path string, statusCode int, containedText string) PathHTTPChecker {
+func NewPathReadyChecker(opts *CheckOpts, skip bool, name string, path string, statusCode int, containedText string) PathHTTPChecker {
 	cv := opts.manager.aem.config.Values()
 
 	return PathHTTPChecker{
+		Skip:           skip,
 		Name:           name,
 		Path:           path,
 		RequestTimeout: cv.GetDuration("instance.check.path_ready.timeout"),
@@ -401,10 +414,11 @@ func NewPathReadyChecker(opts *CheckOpts, name string, path string, statusCode i
 }
 
 func (c PathHTTPChecker) Spec() CheckSpec {
-	return CheckSpec{Mandatory: false}
+	return CheckSpec{Skip: c.Skip, Mandatory: false}
 }
 
 type PathHTTPChecker struct {
+	Skip           bool
 	Name           string
 	Path           string
 	RequestTimeout time.Duration

--- a/pkg/instance_manager_check.go
+++ b/pkg/instance_manager_check.go
@@ -131,6 +131,9 @@ func (im *InstanceManager) CheckOne(i Instance, checks []Checker) ([]CheckResult
 func (im *InstanceManager) checkOne(ctx context.Context, i Instance, checks []Checker) ([]CheckResult, error) {
 	var results []CheckResult
 	for _, check := range checks {
+		if check.Spec().Skip {
+			continue
+		}
 		result := check.Check(ctx.Value(checkContextKey{}).(CheckContext), i)
 		results = append(results, result)
 		if result.abort {

--- a/pkg/instance_manager_check.go
+++ b/pkg/instance_manager_check.go
@@ -18,15 +18,16 @@ type CheckOpts struct {
 	AwaitStrict   bool
 	Skip          bool
 
-	Reachable     ReachableHTTPChecker
-	BundleStable  BundleStableChecker
-	EventStable   EventStableChecker
-	Installer     InstallerChecker
-	AwaitStarted  AwaitChecker
-	Unreachable   ReachableHTTPChecker
-	StatusStopped StatusStoppedChecker
-	AwaitStopped  AwaitChecker
-	LoginPage     PathHTTPChecker
+	Reachable       ReachableHTTPChecker
+	BundleStable    BundleStableChecker
+	EventStable     EventStableChecker
+	ComponentStable ComponentStableChecker
+	Installer       InstallerChecker
+	AwaitStarted    AwaitChecker
+	Unreachable     ReachableHTTPChecker
+	StatusStopped   StatusStoppedChecker
+	AwaitStopped    AwaitChecker
+	LoginPage       PathHTTPChecker
 }
 
 func NewCheckOpts(manager *InstanceManager) *CheckOpts {
@@ -43,6 +44,7 @@ func NewCheckOpts(manager *InstanceManager) *CheckOpts {
 	result.Reachable = NewReachableChecker(result, true)
 	result.BundleStable = NewBundleStableChecker(result)
 	result.EventStable = NewEventStableChecker(result)
+	result.ComponentStable = NewComponentStableChecker(result)
 	result.AwaitStarted = NewAwaitChecker(result, "started")
 	result.Installer = NewInstallerChecker(result)
 	result.StatusStopped = NewStatusStoppedChecker()
@@ -174,6 +176,7 @@ func (im *InstanceManager) AwaitStarted(instances []Instance) error {
 			im.CheckOpts.EventStable,
 			im.CheckOpts.Installer,
 			im.CheckOpts.LoginPage,
+			im.CheckOpts.ComponentStable,
 		}
 	}
 	return im.CheckUntilDone(instances, im.CheckOpts, checkers)

--- a/pkg/osgi/component.go
+++ b/pkg/osgi/component.go
@@ -89,8 +89,10 @@ const (
 )
 
 const (
-	ComponentStateActive    = "active"
-	ComponentStateSatisfied = "satisfied"
-	ComponentStateNoConfig  = "no config"
-	ComponentStateDisabled  = "disabled"
+	ComponentStateActive               = "active"
+	ComponentStateSatisfied            = "satisfied"
+	ComponentStateUnsatisfiedReference = "unsatisfied (reference)"
+	ComponentStateNoConfig             = "no config"
+	ComponentStateDisabled             = "disabled"
+	ComponentStateFailedActivation     = "failed activation"
 )

--- a/pkg/project/app_classic/aem/default/etc/aem.yml
+++ b/pkg/project/app_classic/aem/default/etc/aem.yml
@@ -93,6 +93,7 @@ instance:
       received_max_age: 5s
     # OSGi components state tracking
     component_stable:
+      pids_ignored: []
       pids_failed_activation: ["*"]
       pids_unsatisfied_reference: []
     # Sling Installer tracking

--- a/pkg/project/app_classic/aem/default/etc/aem.yml
+++ b/pkg/project/app_classic/aem/default/etc/aem.yml
@@ -91,6 +91,10 @@ instance:
         - "org.osgi.service.component.runtime.ServiceComponentRuntime"
         - "java.util.ResourceBundle"
       received_max_age: 5s
+    # OSGi components state tracking
+    component_stable:
+      pids_failed_activation: ["*"]
+      pids_unsatisfied_reference: []
     # Sling Installer tracking
     installer:
       # JMX state checking

--- a/pkg/project/app_cloud/aem/default/etc/aem.yml
+++ b/pkg/project/app_cloud/aem/default/etc/aem.yml
@@ -93,6 +93,7 @@ instance:
       received_max_age: 5s
     # OSGi components state tracking
     component_stable:
+      pids_ignored: []
       pids_failed_activation: ["*"]
       pids_unsatisfied_reference: []
     # Sling Installer tracking

--- a/pkg/project/app_cloud/aem/default/etc/aem.yml
+++ b/pkg/project/app_cloud/aem/default/etc/aem.yml
@@ -91,6 +91,10 @@ instance:
         - "org.osgi.service.component.runtime.ServiceComponentRuntime"
         - "java.util.ResourceBundle"
       received_max_age: 5s
+    # OSGi components state tracking
+    component_stable:
+      pids_failed_activation: ["*"]
+      pids_unsatisfied_reference: []
     # Sling Installer tracking
     installer:
       # JMX state checking

--- a/pkg/project/instance/aem/default/etc/aem.yml
+++ b/pkg/project/instance/aem/default/etc/aem.yml
@@ -89,6 +89,10 @@ instance:
         - "org.osgi.service.component.runtime.ServiceComponentRuntime"
         - "java.util.ResourceBundle"
       received_max_age: 5s
+    # OSGi components state tracking
+    component_stable:
+      pids_failed_activation: ["*"]
+      pids_unsatisfied_reference: []
     # Sling Installer tracking
     installer:
       # JMX state checking

--- a/pkg/project/instance/aem/default/etc/aem.yml
+++ b/pkg/project/instance/aem/default/etc/aem.yml
@@ -91,6 +91,7 @@ instance:
       received_max_age: 5s
     # OSGi components state tracking
     component_stable:
+      pids_ignored: []
       pids_failed_activation: ["*"]
       pids_unsatisfied_reference: []
     # Sling Installer tracking


### PR DESCRIPTION
considering adding to project-specific aem.yml

```yml
    component_stable:
      pids_ignored:
        - "com.mysite.aem.oldone.StillNeededButFailingTemporarily"
        - "com.mysite.aem.oldone.AnotherStillNeededButFailingTemporarily"
      pids_failed_activation: ["*"]
      pids_unsatisfied_reference: ["com.mysite.*"]
```

then AEMC will detect potential problems with OSGi service right after deploying them to the instance.

WDYT? :) 