### PR TITLE
#250 Add `-tags timetzdata` to the `go build` for Windows

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,25 +17,12 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
+      - windows
       - darwin
+    tags:
+      - timetzdata
     ldflags:
       - "-s -w -X main.appVersion={{ .Version }} -X main.appCommit={{ .Commit }} -X main.appCommitDate={{.CommitDate}}"
-  - id: aemc-cli-windows
-      binary: aem
-      main: './cmd/aem'
-      tags:
-        - aem
-        - cli
-        - provision
-        - config_mgmt
-      env:
-        - CGO_ENABLED=0
-      goos:
-        - windows
-      tags:
-        - timetzdata
-      ldflags:
-        - "-s -w -X main.appVersion={{ .Version }} -X main.appCommit={{ .Commit }} -X main.appCommitDate={{.CommitDate}}"
 
 dockers:
   - id: aemc-cli

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,10 +17,25 @@ builds:
       - CGO_ENABLED=0
     goos:
       - linux
-      - windows
       - darwin
     ldflags:
       - "-s -w -X main.appVersion={{ .Version }} -X main.appCommit={{ .Commit }} -X main.appCommitDate={{.CommitDate}}"
+  - id: aemc-cli-windows
+      binary: aem
+      main: './cmd/aem'
+      tags:
+        - aem
+        - cli
+        - provision
+        - config_mgmt
+      env:
+        - CGO_ENABLED=0
+      goos:
+        - windows
+      tags:
+        - timetzdata
+      ldflags:
+        - "-s -w -X main.appVersion={{ .Version }} -X main.appCommit={{ .Commit }} -X main.appCommitDate={{.CommitDate}}"
 
 dockers:
   - id: aemc-cli

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ install:
 other_build:
 	GOARCH=amd64 GOOS=darwin go build --ldflags "${.LD_FLAGS}" -o bin/aem.darwin ./cmd/aem
 	GOARCH=amd64 GOOS=linux go build --ldflags "${.LD_FLAGS}" -o bin/aem.linux ./cmd/aem
-	GOARCH=amd64 GOOS=windows go build --ldflags "${.LD_FLAGS}" -o bin/aem.exe ./cmd/aem
+	GOARCH=amd64 GOOS=windows go build -tags timetzdata --ldflags "${.LD_FLAGS}" -o bin/aem.exe ./cmd/aem
 
 clean:
 	go clean

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 .GIT_COMMIT_DATE=$(shell git log -1 --date=format:'%Y-%m-%dT%H:%M:%S' --format=%cd)
 .GIT_VERSION=$(shell git describe --tags 2>/dev/null || echo "$(.GIT_COMMIT)")
 .LD_FLAGS=$(shell echo "-s -w -X main.appVersion=${.GIT_VERSION} -X main.appCommit=${.GIT_COMMIT} -X main.appCommitDate=${.GIT_COMMIT_DATE}")
+.TAGS=timetzdata
 
 all: deps test vet fmt lint install
 
@@ -25,15 +26,15 @@ lint:
 	revive -config revive.toml -formatter friendly ./...
 
 build:
-	go build --ldflags "${.LD_FLAGS}" -o bin/aem ./cmd/aem
+	go build -tags "${.TAGS}" --ldflags "${.LD_FLAGS}" -o bin/aem ./cmd/aem
 
 install:
-	go install --ldflags "${.LD_FLAGS}" ./cmd/aem
+	go install -tags "${.TAGS}" --ldflags "${.LD_FLAGS}" ./cmd/aem
 
 other_build:
-	GOARCH=amd64 GOOS=darwin go build --ldflags "${.LD_FLAGS}" -o bin/aem.darwin ./cmd/aem
-	GOARCH=amd64 GOOS=linux go build --ldflags "${.LD_FLAGS}" -o bin/aem.linux ./cmd/aem
-	GOARCH=amd64 GOOS=windows go build -tags timetzdata --ldflags "${.LD_FLAGS}" -o bin/aem.exe ./cmd/aem
+	GOARCH=amd64 GOOS=darwin  go build -tags "${.TAGS}" --ldflags "${.LD_FLAGS}" -o bin/aem.darwin ./cmd/aem
+	GOARCH=amd64 GOOS=linux   go build -tags "${.TAGS}" --ldflags "${.LD_FLAGS}" -o bin/aem.linux  ./cmd/aem
+	GOARCH=amd64 GOOS=windows go build -tags "${.TAGS}" --ldflags "${.LD_FLAGS}" -o bin/aem.exe    ./cmd/aem
 
 clean:
 	go clean


### PR DESCRIPTION
fixes #250 