### PR TITLE
fixed namespace cleanup when filename contains namespace (e.g. _cq_, _jcr_, _sling_)

### DIFF
--- a/pkg/content_manager.go
+++ b/pkg/content_manager.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	NamespacePattern = "(\\\\|/)_([a-zA-Z0-9]+)_"
+	NamespacePattern = "\\\\|/_[a-zA-Z0-9]+_"
 )
 
 var (


### PR DESCRIPTION
…_jcr_, _sling_)