### PR TITLE
Add user private keys management commands: add, delete

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/nwaples/rardecode v1.1.3 // indirect
+	github.com/pavlo-v-chernykh/keystore-go/v4 v4.5.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.1 // indirect
 	github.com/pierrec/lz4/v4 v4.1.19 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
@@ -80,3 +81,4 @@ require (
 	golang.org/x/text v0.14.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 )
+

--- a/go.sum
+++ b/go.sum
@@ -107,6 +107,10 @@ github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6
 github.com/otiai10/copy v1.14.0 h1:dCI/t1iTdYGtkvCuBG2BgR6KZa83PTclw4U5n2wAllU=
 github.com/otiai10/copy v1.14.0/go.mod h1:ECfuL02W+/FkTWZWgQqXPWZgW9oeKCSQ5qVfSc4qc4w=
 github.com/otiai10/mint v1.5.1 h1:XaPLeE+9vGbuyEHem1JNk3bYc7KKqyI/na0/mLd/Kks=
+github.com/pavlo-v-chernykh/keystore-go v2.1.0+incompatible h1:/g2gGGxrs2aQU7IrnLlFL0h3CrBrhwNFpKYhXh/gKm4=
+github.com/pavlo-v-chernykh/keystore-go v2.1.0+incompatible/go.mod h1:FUVGm7LLk1CudKS/gecQcL9T6GpdP2M97mJTuRzA5rw=
+github.com/pavlo-v-chernykh/keystore-go/v4 v4.5.0 h1:2nosf3P75OZv2/ZO/9Px5ZgZ5gbKrzA3joN1QMfOGMQ=
+github.com/pavlo-v-chernykh/keystore-go/v4 v4.5.0/go.mod h1:lAVhWwbNaveeJmxrxuSTxMgKpF6DjnuVpn6T8WiBwYQ=
 github.com/pelletier/go-toml/v2 v2.1.1 h1:LWAJwfNvjQZCFIDKWYQaM62NcYeYViCmWIwmOStowAI=
 github.com/pelletier/go-toml/v2 v2.1.1/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/pierrec/lz4/v4 v4.1.2/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=

--- a/pkg/keystore/keystore_status.go
+++ b/pkg/keystore/keystore_status.go
@@ -2,9 +2,10 @@ package keystore
 
 import (
 	"bytes"
+	"io"
+
 	"github.com/samber/lo"
 	"github.com/wttech/aemc/pkg/common/fmtx"
-	"io"
 )
 
 type Status struct {
@@ -33,4 +34,10 @@ func (s *Status) MarshalText() string {
 		return map[string]any{"alias": c.Alias}
 	})))
 	return bs.String()
+}
+
+func (s *Status) HasAlias(privateKeyAlias string) bool {
+	return lo.ContainsBy(s.PrivateKeys, func(c PrivateKey) bool {
+		return c.Alias == privateKeyAlias
+	})
 }


### PR DESCRIPTION
```
$ ./bin/aem auth user keystore key add --scope we-retail --id DSCP-athB1NYLBXvdTuN -A  --key-alias test-alias --keystore-file ~/test.keystore --keystore-password abcd
INFO[2025-05-26 22:23:50] User Keystore key added             

$ ./bin/aem auth user keystore key add --scope we-retail --id DSCP-athB1NYLBXvdTuN -A  --key-alias test-alias --keystore-file ~/test.keystore --keystore-password abcd
INFO[2025-05-26 22:23:52] User Keystore key already exists    

$ ./bin/aem auth user keystore key rm --scope we-retail --id DSCP-athB1NYLBXvdTuN -A --key-alias test-alias
INFO[2025-05-26 22:24:05] User Keystore key deleted           

$ ./bin/aem auth user keystore key rm --scope we-retail --id DSCP-athB1NYLBXvdTuN -A --key-alias test-alias
INFO[2025-05-26 22:24:07] User Keystore key does not exist    
```